### PR TITLE
[BE] 인수테스트, 문서화테스트 환경을 세팅한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,3 +61,14 @@ tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
 }
+
+task createDocument(type: Copy) {
+    dependsOn asciidoctor
+
+    from file("build/asciidoc/html5/index.html")
+    into file("src/main/resources/static")
+}
+
+bootJar {
+    dependsOn createDocument
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AcceptanceTest.java
@@ -1,0 +1,21 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setPort() {
+        RestAssured.port = port;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -1,0 +1,34 @@
+package com.woowacourse.gongcheck.documentation;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest({
+
+})
+@ExtendWith(RestDocumentationExtension.class)
+class DocumentationTest {
+
+    protected MockMvcRequestSpecification docsGiven;
+
+    @BeforeEach
+    void setDocsGiven(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        docsGiven = RestAssuredMockMvc.given()
+                .mockMvc(MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                        .apply(documentationConfiguration(restDocumentation)
+                                .operationPreprocessors()
+                                .withRequestDefaults(prettyPrint())
+                                .withResponseDefaults(prettyPrint()))
+                        .build()).log().all();
+    }
+}


### PR DESCRIPTION
## issue
- #10 

## 코드 설명
- `build.gradle` 내 documentation 생성을 위한 스크립트 추가
    - `./gradlew bootJar` 실행 시 document 생성 스크립트
- `AcceptanceTest`추가 -> 차후 `DirtiesContext` 제거 필요
- `DocumentationTest` 추가 -> 사용 시 상속받은 후 `docsGiven` 사용 필요
