### PR TITLE
[BE] 공간 작업의 새로운 진행작업을 추가하는 API를 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -5,6 +5,9 @@ import com.woowacourse.gongcheck.domain.job.JobRepository;
 import com.woowacourse.gongcheck.domain.member.Member;
 import com.woowacourse.gongcheck.domain.member.MemberRepository;
 import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.domain.task.TaskRepository;
+import com.woowacourse.gongcheck.domain.task.Tasks;
+import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,12 +18,14 @@ public class TaskService {
 
     private final MemberRepository memberRepository;
     private final JobRepository jobRepository;
+    private final TaskRepository taskRepository;
     private final RunningTaskRepository runningTaskRepository;
 
     public TaskService(final MemberRepository memberRepository, final JobRepository jobRepository,
-                       final RunningTaskRepository runningTaskRepository) {
+                       final TaskRepository taskRepository, final RunningTaskRepository runningTaskRepository) {
         this.memberRepository = memberRepository;
         this.jobRepository = jobRepository;
+        this.taskRepository = taskRepository;
         this.runningTaskRepository = runningTaskRepository;
     }
 
@@ -30,5 +35,10 @@ public class TaskService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
         Job job = jobRepository.findBySpaceMemberAndId(host, jobId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 작업입니다."));
+
+        Tasks tasks = new Tasks(taskRepository.findAllBySectionJob(job));
+        if (runningTaskRepository.existsByTaskIdIn(tasks.getTaskIds())) {
+            throw new BusinessException("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -40,5 +40,6 @@ public class TaskService {
         if (runningTaskRepository.existsByTaskIdIn(tasks.getTaskIds())) {
             throw new BusinessException("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");
         }
+        runningTaskRepository.saveAll(tasks.createRunningTasks());
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -28,7 +28,7 @@ public class TaskService {
     public void createNewRunningTask(final Long hostId, final Long jobId) {
         Member host = memberRepository.findById(hostId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
-        Job job = jobRepository.findById(jobId)
+        Job job = jobRepository.findBySpaceMemberAndId(host, jobId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 작업입니다."));
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -30,7 +30,7 @@ public class TaskService {
     }
 
     @Transactional
-    public void createNewRunningTask(final Long hostId, final Long jobId) {
+    public void createNewRunningTasks(final Long hostId, final Long jobId) {
         Member host = memberRepository.findById(hostId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
         Job job = jobRepository.findBySpaceMemberAndId(host, jobId)

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -36,6 +36,10 @@ public class TaskService {
         Job job = jobRepository.findBySpaceMemberAndId(host, jobId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 작업입니다."));
 
+        createAndSaveNewRunningTasks(job);
+    }
+
+    private void createAndSaveNewRunningTasks(final Job job) {
         Tasks tasks = new Tasks(taskRepository.findAllBySectionJob(job));
         if (runningTaskRepository.existsByTaskIdIn(tasks.getTaskIds())) {
             throw new BusinessException("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/TaskService.java
@@ -1,0 +1,34 @@
+package com.woowacourse.gongcheck.application;
+
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.member.Member;
+import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TaskService {
+
+    private final MemberRepository memberRepository;
+    private final JobRepository jobRepository;
+    private final RunningTaskRepository runningTaskRepository;
+
+    public TaskService(final MemberRepository memberRepository, final JobRepository jobRepository,
+                       final RunningTaskRepository runningTaskRepository) {
+        this.memberRepository = memberRepository;
+        this.jobRepository = jobRepository;
+        this.runningTaskRepository = runningTaskRepository;
+    }
+
+    @Transactional
+    public void createNewRunningTask(final Long hostId, final Long jobId) {
+        Member host = memberRepository.findById(hostId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
+        Job job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 작업입니다."));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/job/JobRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/job/JobRepository.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.domain.job;
 
 import com.woowacourse.gongcheck.domain.member.Member;
 import com.woowacourse.gongcheck.domain.space.Space;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JobRepository extends JpaRepository<Job, Long> {
 
     Slice<Job> findBySpaceMemberAndSpace(final Member member, final Space space, final Pageable pageable);
+
+    Optional<Job> findBySpaceMemberAndId(final Member member, final Long id);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
@@ -4,11 +4,8 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.MapsId;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,12 +17,8 @@ import org.hibernate.annotations.ColumnDefault;
 public class RunningTask {
 
     @Id
+    @JoinColumn(name = "task_id")
     private Long taskId;
-
-    @MapsId("taskId")
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "task_id", nullable = false)
-    private Task task;
 
     @Column(name = "is_checked", nullable = false)
     @ColumnDefault("false")
@@ -38,9 +31,8 @@ public class RunningTask {
     }
 
     @Builder
-    public RunningTask(Long taskId, Task task, boolean isChecked, LocalDateTime createdAt) {
+    public RunningTask(Long taskId, boolean isChecked, LocalDateTime createdAt) {
         this.taskId = taskId;
-        this.task = task;
         this.isChecked = isChecked;
         this.createdAt = createdAt;
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepository.java
@@ -1,6 +1,10 @@
 package com.woowacourse.gongcheck.domain.task;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface RunningTaskRepository extends JpaRepository<RunningTask, Long> {
+
+    boolean existsByTaskIdIn(@Param("taskIds") final List<Long> taskIds);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
@@ -51,6 +51,14 @@ public class Task {
         this.updatedAt = updatedAt;
     }
 
+    public RunningTask createRunningTask() {
+        return RunningTask.builder()
+                .taskId(id)
+                .isChecked(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
@@ -1,6 +1,10 @@
 package com.woowacourse.gongcheck.domain.task;
 
+import com.woowacourse.gongcheck.domain.job.Job;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    List<Task> findAllBySectionJob(final Job job);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
@@ -12,6 +12,12 @@ public class Tasks {
         this.tasks = tasks;
     }
 
+    public List<RunningTask> createRunningTasks() {
+        return tasks.stream()
+                .map(Task::createRunningTask)
+                .collect(Collectors.toList());
+    }
+
     public List<Long> getTaskIds() {
         return tasks.stream()
                 .map(Task::getId)

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
@@ -1,0 +1,37 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class Tasks {
+
+    private final List<Task> tasks;
+
+    public Tasks(final List<Task> tasks) {
+        this.tasks = tasks;
+    }
+
+    public List<Long> getTaskIds() {
+        return tasks.stream()
+                .map(Task::getId)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Tasks tasks1 = (Tasks) o;
+        return Objects.equals(tasks, tasks1.tasks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tasks);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/exception/BusinessException.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/exception/BusinessException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.gongcheck.exception;
+
+public class BusinessException extends RuntimeException {
+
+    public BusinessException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/exception/ControllerAdvice.java
@@ -19,6 +19,11 @@ public class ControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.from(e));
     }
 
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(final RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(e));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(final MethodArgumentNotValidException e) {
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
@@ -19,8 +19,8 @@ public class TaskController {
     }
 
     @PostMapping("/jobs/{jobId}/tasks/new")
-    public ResponseEntity<Void> createNewTasks(@AuthenticationPrincipal Long hostId,
-                                               @PathVariable Long jobId) {
+    public ResponseEntity<Void> createNewTasks(@AuthenticationPrincipal final Long hostId,
+                                               @PathVariable final Long jobId) {
         taskService.createNewRunningTask(hostId, jobId);
         return ResponseEntity.created(URI.create("/api/jobs/" + jobId + "/tasks")).build();
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
@@ -21,7 +21,7 @@ public class TaskController {
     @PostMapping("/jobs/{jobId}/tasks/new")
     public ResponseEntity<Void> createNewTasks(@AuthenticationPrincipal final Long hostId,
                                                @PathVariable final Long jobId) {
-        taskService.createNewRunningTask(hostId, jobId);
+        taskService.createNewRunningTasks(hostId, jobId);
         return ResponseEntity.created(URI.create("/api/jobs/" + jobId + "/tasks")).build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
@@ -1,0 +1,27 @@
+package com.woowacourse.gongcheck.presentation;
+
+import com.woowacourse.gongcheck.application.TaskService;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(final TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @PostMapping("/jobs/{jobId}/tasks/new")
+    public ResponseEntity<Void> createNewTasks(@AuthenticationPrincipal Long hostId,
+                                               @PathVariable Long jobId) {
+        taskService.createNewRunningTask(hostId, jobId);
+        return ResponseEntity.created(URI.create("/api/jobs/" + jobId + "/tasks")).build();
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,2 +1,9 @@
 INSERT INTO member (space_password, created_at) VALUES ('1234', current_timestamp());
 INSERT INTO space (member_id, name, created_at) VALUES (1, '잠실', current_timestamp());
+INSERT INTO job (space_id, name, created_at) VALUES (1, '청소', current_timestamp());
+INSERT INTO section (job_id, name, created_at) VALUES (1, '트랙룸', current_timestamp());
+INSERT INTO task (section_id, name, created_at) VALUES (1, '책상 청소', current_timestamp());
+INSERT INTO task (section_id, name, created_at) VALUES (1, '빈백 털기', current_timestamp());
+INSERT INTO section (job_id, name, created_at) VALUES (1, '굿샷 강의장', current_timestamp());
+INSERT INTO task (section_id, name, created_at) VALUES (2, '책상 청소', current_timestamp());
+INSERT INTO task (section_id, name, created_at) VALUES (2, '의자 청소', current_timestamp());

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
@@ -1,0 +1,42 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class TaskAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 새로운_진행작업을_생성한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(guestEnterRequest)
+                .when().post("/api/hosts/1/enter")
+                .then().log().all()
+                .extract()
+                .as(GuestTokenResponse.class)
+                .getToken();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
@@ -28,6 +28,28 @@ class TaskAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
+    @Test
+    void 이미_존재하는_진행작업이_있는데_생성하는_경우_실패한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .extract();
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
     private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
         return RestAssured
                 .given().log().all()

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -6,6 +6,7 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생�
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.gongcheck.domain.job.Job;
@@ -16,12 +17,15 @@ import com.woowacourse.gongcheck.domain.section.Section;
 import com.woowacourse.gongcheck.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTask;
 import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.domain.task.Task;
 import com.woowacourse.gongcheck.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -94,5 +98,23 @@ class TaskServiceTest {
         assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), job.getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");
+    }
+
+    @Test
+    void 정상적으로_새로운_진행_작업을_생성한다() {
+        Member host = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task1 = Task_생성(section, "책상 청소");
+        Task task2 = Task_생성(section, "의자 넣기");
+        taskRepository.saveAll(List.of(task1, task2));
+
+        taskService.createNewRunningTask(host.getId(), job.getId());
+        List<RunningTask> result = runningTaskRepository.findAllById(Stream.of(task1, task2)
+                .map(Task::getId)
+                .collect(Collectors.toList()));
+
+        assertThat(result).hasSize(2);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -1,0 +1,51 @@
+package com.woowacourse.gongcheck.application;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Member_생성;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.member.Member;
+import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.exception.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class TaskServiceTest {
+
+    @Autowired
+    private TaskService taskService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private RunningTaskRepository runningTaskRepository;
+
+    @Test
+    void 존재하지_않는_호스트로_새로운_작업을_진행하려하는_경우_예외가_발생한다() {
+        assertThatThrownBy(() -> taskService.createNewRunningTask(0L, 1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 호스트입니다.");
+    }
+
+    @Test
+    void 존재하지_않는_작업의_새로운_작업을_진행하려는_경우_예외가_발생한다() {
+        Member host = memberRepository.save(Member_생성("1234"));
+
+        assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), 0L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 작업입니다.");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -1,11 +1,15 @@
 package com.woowacourse.gongcheck.application;
 
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Member_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.job.JobRepository;
 import com.woowacourse.gongcheck.domain.member.Member;
 import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.exception.NotFoundException;
@@ -45,6 +49,18 @@ class TaskServiceTest {
         Member host = memberRepository.save(Member_생성("1234"));
 
         assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), 0L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 작업입니다.");
+    }
+
+    @Test
+    void 다른_호스트의_작업의_새로운_작업을_진행하려는_경우_예외가_발생한다() {
+        Member host1 = memberRepository.save(Member_생성("1234"));
+        Member host2 = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host2, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+
+        assertThatThrownBy(() -> taskService.createNewRunningTask(host1.getId(), job.getId()))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -2,17 +2,26 @@ package com.woowacourse.gongcheck.application;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Member_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.job.JobRepository;
 import com.woowacourse.gongcheck.domain.member.Member;
 import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.domain.task.Task;
+import com.woowacourse.gongcheck.domain.task.TaskRepository;
+import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,6 +42,12 @@ class TaskServiceTest {
 
     @Autowired
     private JobRepository jobRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
 
     @Autowired
     private RunningTaskRepository runningTaskRepository;
@@ -63,5 +78,21 @@ class TaskServiceTest {
         assertThatThrownBy(() -> taskService.createNewRunningTask(host1.getId(), job.getId()))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
+    }
+
+    @Test
+    void 이미_진행중인_작업이_존재하는데_새로운_작업을_진행하려는_경우_예외가_발생한다() {
+        Member host = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task1 = Task_생성(section, "책상 청소");
+        Task task2 = Task_생성(section, "의자 넣기");
+        taskRepository.saveAll(List.of(task1, task2));
+        runningTaskRepository.saveAll(List.of(RunningTask_생성(task1), RunningTask_생성(task2)));
+
+        assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), job.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -58,7 +58,7 @@ class TaskServiceTest {
         Member host1 = memberRepository.save(Member_생성("1234"));
         Member host2 = memberRepository.save(Member_생성("1234"));
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
 
         assertThatThrownBy(() -> taskService.createNewRunningTask(host1.getId(), job.getId()))
                 .isInstanceOf(NotFoundException.class)

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -58,7 +58,7 @@ class TaskServiceTest {
 
     @Test
     void 존재하지_않는_호스트로_새로운_작업을_진행하려하는_경우_예외가_발생한다() {
-        assertThatThrownBy(() -> taskService.createNewRunningTask(0L, 1L))
+        assertThatThrownBy(() -> taskService.createNewRunningTasks(0L, 1L))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 호스트입니다.");
     }
@@ -67,7 +67,7 @@ class TaskServiceTest {
     void 존재하지_않는_작업의_새로운_작업을_진행하려는_경우_예외가_발생한다() {
         Member host = memberRepository.save(Member_생성("1234"));
 
-        assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), 0L))
+        assertThatThrownBy(() -> taskService.createNewRunningTasks(host.getId(), 0L))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
     }
@@ -79,7 +79,7 @@ class TaskServiceTest {
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
 
-        assertThatThrownBy(() -> taskService.createNewRunningTask(host1.getId(), job.getId()))
+        assertThatThrownBy(() -> taskService.createNewRunningTasks(host1.getId(), job.getId()))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
     }
@@ -95,7 +95,7 @@ class TaskServiceTest {
         taskRepository.saveAll(List.of(task1, task2));
         runningTaskRepository.saveAll(List.of(RunningTask_생성(task1), RunningTask_생성(task2)));
 
-        assertThatThrownBy(() -> taskService.createNewRunningTask(host.getId(), job.getId()))
+        assertThatThrownBy(() -> taskService.createNewRunningTasks(host.getId(), job.getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.");
     }
@@ -110,7 +110,7 @@ class TaskServiceTest {
         Task task2 = Task_생성(section, "의자 넣기");
         taskRepository.saveAll(List.of(task1, task2));
 
-        taskService.createNewRunningTask(host.getId(), job.getId());
+        taskService.createNewRunningTasks(host.getId(), job.getId());
         List<RunningTask> result = runningTaskRepository.findAllById(Stream.of(task1, task2)
                 .map(Task::getId)
                 .collect(Collectors.toList()));

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -7,10 +7,12 @@ import com.woowacourse.gongcheck.application.GuestAuthService;
 import com.woowacourse.gongcheck.application.JjwtTokenProvider;
 import com.woowacourse.gongcheck.application.JobService;
 import com.woowacourse.gongcheck.application.SpaceService;
+import com.woowacourse.gongcheck.application.TaskService;
 import com.woowacourse.gongcheck.presentation.AuthenticationContext;
 import com.woowacourse.gongcheck.presentation.GuestAuthController;
 import com.woowacourse.gongcheck.presentation.JobController;
 import com.woowacourse.gongcheck.presentation.SpaceController;
+import com.woowacourse.gongcheck.presentation.TaskController;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +27,8 @@ import org.springframework.web.context.WebApplicationContext;
 @WebMvcTest({
         GuestAuthController.class,
         SpaceController.class,
-        JobController.class
+        JobController.class,
+        TaskController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 class DocumentationTest {
@@ -40,6 +43,9 @@ class DocumentationTest {
 
     @MockBean
     protected JobService jobService;
+
+    @MockBean
+    protected TaskService taskService;
 
     @MockBean
     protected JjwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -1,0 +1,26 @@
+package com.woowacourse.gongcheck.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class TaskDocumentation extends DocumentationTest {
+
+    @Test
+    void 새_진행_작업_생성() {
+        doNothing().when(taskService).createNewRunningTask(anyLong(), any());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        docsGiven
+                .header("Authorization", "Bearer jwt.token.here")
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .apply(document("tasks/create"))
+                .statusCode(HttpStatus.CREATED.value());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -13,7 +13,7 @@ class TaskDocumentation extends DocumentationTest {
 
     @Test
     void 새_진행_작업_생성() {
-        doNothing().when(taskService).createNewRunningTask(anyLong(), any());
+        doNothing().when(taskService).createNewRunningTasks(anyLong(), any());
         when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
         docsGiven

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
@@ -11,6 +11,7 @@ import com.woowacourse.gongcheck.domain.member.MemberRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -44,5 +45,28 @@ class JobRepositoryTest {
                 () -> assertThat(result.getSize()).isEqualTo(2),
                 () -> assertThat(result.hasNext()).isTrue()
         );
+    }
+
+    @Test
+    void 멤버와_아이디로_작업을_조회한다() {
+        Member host = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+
+        Optional<Job> result = jobRepository.findBySpaceMemberAndId(host, job.getId());
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void 다른_호스트의_작업을_조회할_경우_빈_값이_조회된다() {
+        Member host1 = memberRepository.save(Member_생성("1234"));
+        Member host2 = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host2, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+
+        Optional<Job> result = jobRepository.findBySpaceMemberAndId(host1, job.getId());
+
+        assertThat(result).isEmpty();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
@@ -51,7 +51,7 @@ class JobRepositoryTest {
     void 멤버와_아이디로_작업을_조회한다() {
         Member host = memberRepository.save(Member_생성("1234"));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
 
         Optional<Job> result = jobRepository.findBySpaceMemberAndId(host, job.getId());
 
@@ -63,7 +63,7 @@ class JobRepositoryTest {
         Member host1 = memberRepository.save(Member_생성("1234"));
         Member host2 = memberRepository.save(Member_생성("1234"));
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "트랙룸"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
 
         Optional<Job> result = jobRepository.findBySpaceMemberAndId(host1, job.getId());
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
@@ -45,7 +45,7 @@ class RunningTaskRepositoryTest {
     private RunningTaskRepository runningTaskRepository;
 
     @Nested
-    class 테스크에_진행중인_테스트가_있는지_확인한다 {
+    class 테스크에_진행중인_테스크가_있는지_확인한다 {
 
         private Member host;
         private Space space;

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Member_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.member.Member;
+import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.section.SectionRepository;
+import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class RunningTaskRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private RunningTaskRepository runningTaskRepository;
+
+    @Nested
+    class 테스크에_진행중인_테스트가_있는지_확인한다 {
+
+        private Member host;
+        private Space space;
+        private Job job;
+        private Section section;
+        private Task task;
+
+        @BeforeEach
+        void setUp() {
+            host = memberRepository.save(Member_생성("1234"));
+            space = spaceRepository.save(Space_생성(host, "잠실"));
+            job = jobRepository.save(Job_생성(space, "청소"));
+            section = sectionRepository.save(Section_생성(job, "트랙룸"));
+            task = taskRepository.save(Task_생성(section, "책상 청소"));
+        }
+
+        @Test
+        void 존재하는_경우() {
+            runningTaskRepository.save(RunningTask_생성(task));
+            boolean result = runningTaskRepository.existsByTaskIdIn(List.of(task.getId()));
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 존재하지_않는_경우() {
+            boolean result = runningTaskRepository.existsByTaskIdIn(List.of(task.getId()));
+
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
@@ -43,11 +43,13 @@ class TaskRepositoryTest {
         Member host = memberRepository.save(Member_생성("1234"));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
-        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-        taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+        Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Section section2 = sectionRepository.save(Section_생성(job, "굿샷 강의장"));
+        taskRepository.saveAll(List.of(Task_생성(section1, "책상 청소"), Task_생성(section1, "빈백 정리")));
+        taskRepository.saveAll(List.of(Task_생성(section2, "책상 청소"), Task_생성(section2, "의자 넣기")));
 
         List<Task> result = taskRepository.findAllBySectionJob(job);
 
-        assertThat(result).hasSize(2);
+        assertThat(result).hasSize(4);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Member_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.member.Member;
+import com.woowacourse.gongcheck.domain.member.MemberRepository;
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.section.SectionRepository;
+import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class TaskRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Test
+    void Job이_가진_모든_Task를_조회한다() {
+        Member host = memberRepository.save(Member_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+
+        List<Task> result = taskRepository.findAllBySectionJob(job);
+
+        assertThat(result).hasSize(2);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskTest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TaskTest {
+
+    @Test
+    void RunningTask를_생성한다() {
+        Task task = Task.builder()
+                .id(1L)
+                .name("책상 청소")
+                .build();
+
+        assertThat(task.createRunningTask().getTaskId()).isEqualTo(1L);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -2,7 +2,10 @@ package com.woowacourse.gongcheck.fixture;
 
 import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.member.Member;
+import com.woowacourse.gongcheck.domain.section.Section;
 import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.task.RunningTask;
+import com.woowacourse.gongcheck.domain.task.Task;
 import java.time.LocalDateTime;
 
 public class FixtureFactory {
@@ -25,6 +28,30 @@ public class FixtureFactory {
         return Job.builder()
                 .space(space)
                 .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Section Section_생성(final Job job, final String name) {
+        return Section.builder()
+                .job(job)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Task Task_생성(final Section section, final String name) {
+        return Task.builder()
+                .section(section)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static RunningTask RunningTask_생성(final Task task) {
+        return RunningTask.builder()
+                .taskId(task.getId())
+                .isChecked(false)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/ControllerTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.presentation;
 
 import com.woowacourse.gongcheck.application.GuestAuthService;
 import com.woowacourse.gongcheck.application.JwtTokenProvider;
+import com.woowacourse.gongcheck.application.TaskService;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,7 +12,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @WebMvcTest({
-        GuestAuthController.class
+        GuestAuthController.class,
+        TaskController.class
 })
 class ControllerTest {
 
@@ -19,6 +21,9 @@ class ControllerTest {
 
     @MockBean
     protected GuestAuthService guestAuthService;
+
+    @MockBean
+    protected TaskService taskService;
 
     @MockBean
     protected AuthenticationContext authenticationContext;

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
@@ -1,0 +1,32 @@
+package com.woowacourse.gongcheck.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.gongcheck.exception.BusinessException;
+import io.restassured.module.mockmvc.response.MockMvcResponse;
+import io.restassured.response.ExtractableResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class TaskControllerTest extends ControllerTest {
+
+    @Test
+    void 이미_존재하는_진행작업이_있는데_생성하는_경우_예외가_발생한다() {
+        doThrow(new BusinessException("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.")).when(taskService)
+                .createNewRunningTask(anyLong(), anyLong());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
@@ -17,7 +17,7 @@ class TaskControllerTest extends ControllerTest {
     @Test
     void 이미_존재하는_진행작업이_있는데_생성하는_경우_예외가_발생한다() {
         doThrow(new BusinessException("현재 진행중인 작업이 존재하여 새로운 작업을 생성할 수 없습니다.")).when(taskService)
-                .createNewRunningTask(anyLong(), anyLong());
+                .createNewRunningTasks(anyLong(), anyLong());
         when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
         ExtractableResponse<MockMvcResponse> response = given


### PR DESCRIPTION
## issue
- #45 

## 코드 설명
### 실행 시나리오
    1. `Host`를 찾는다
    2. `Job`을 찾는다 (host와 jobid가 일치하도록 검증)
    3. `Job`이 가지고있는 `Tasks`를 찾는다 (`Section` 무관 전체 `Tasks`를 찾는다)
    4. 해당 `Tasks` 중 이미 `RunningTask`를 가진 `Task`가 있다면 예외를 발생시킨다
    5. 없다면 진행중인 작업이 없으므로 `Tasks`로 `RunningTasks`를 만들고 전체 저장함으로써 새로운 진행작업을 추가한다

### RunningTask 필드 수정
- `RunningTask`에서 `Task`를 `@MapsId`로 가지고 있었으나 `RunningTask`에서 `Task`를 가지고 사용할 일도 없을뿐더러 관계가 제대로 형성되지 않아 쿼리가 나가지 않음 -> 결국 `taskId`로만 사용하고 있으므로 해당 필드 제거

### `@Params`를 작성하지않으면 name query가 제대로 생성되지 않음(해당 이슈는 알고있으나 원인을 파악하지 못함)
```java
boolean existsByTaskIdIn(@Param("taskIds") final List<Long> taskIds);
```

### `Tasks` 일급 컬랙션 생성
    - `Task`들의 id list를 쉽게 가져오기위함
    - `Task`들의 새로운 `RunningTask`를 쉽게 생성하기 위함

### Service에서의 bad request 에러 핸들링을 위한 임시 exception 생성
- `BusniessException`이라는 exception을 생성하였으나 해당 부분 어색할 시 리뷰 부탁드립니다

### Url 변환
- `/api/jobs/{jobId}/tasks/new`
- 구현을 진행하다보니 jobs의 tasks들 중 새로운 무언가를 생성한다라는 의미를 전달하는 것이 더 맞다라고 판단
- `/api/jobs/{jobId}`만으로는 사실 rest하다라고 볼 수 없게 되어 보임 (id값에 대한 post는 resources를 관리한다라기에는 거리가 멀어보임)
- 따라서 전체 작업 자체가 `Task` 도메인의 하위 기능들이라 판단하여 `TaskController`, `TaskService`에서 로직을 수행하였음

### data.sql 추가
- 최소화하려하였으나 결과적으로 필요한 데이터가 너무많아 임시로 추가하고 스프린트 2에서 수정 필요