### PR TITLE
[BE] 테스트 픽스쳐 네이밍을 실제 데이터와 비슷하도록 수정한다

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
@@ -35,9 +35,9 @@ class SpaceServiceTest {
     @Test
     void 공간을_조회한다() {
         Host host = hostRepository.save(Host_생성("1234"));
-        Space space1 = Space_생성(host, "test1");
-        Space space2 = Space_생성(host, "test2");
-        Space space3 = Space_생성(host, "test3");
+        Space space1 = Space_생성(host, "잠실");
+        Space space2 = Space_생성(host, "선릉");
+        Space space3 = Space_생성(host, "양평같은방");
         spaceRepository.saveAll(List.of(space1, space2, space3));
 
         SpacesResponse result = spaceService.findPage(host.getId(), PageRequest.of(0, 2));

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -20,8 +20,8 @@ class SpaceDocumentation extends DocumentationTest {
         Host host = Host_생성("1234");
         when(spaceService.findPage(anyLong(), any())).thenReturn(
                 SpacesResponse.of(List.of(
-                                Space_생성(host, "space1"),
-                                Space_생성(host, "space2")),
+                                Space_생성(host, "잠실"),
+                                Space_생성(host, "선릉")),
                         true)
         );
         when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
@@ -27,9 +27,9 @@ class SpaceRepositoryTest {
     @Test
     void 멤버아이디로_공간을_조회한다() {
         Host host = hostRepository.save(Host_생성("1234"));
-        Space space1 = Space_생성(host, "test1");
-        Space space2 = Space_생성(host, "test2");
-        Space space3 = Space_생성(host, "test3");
+        Space space1 = Space_생성(host, "잠실");
+        Space space2 = Space_생성(host, "선릉");
+        Space space3 = Space_생성(host, "양평같은방");
         spaceRepository.saveAll(List.of(space1, space2, space3));
 
         Slice<Space> result = spaceRepository.findByHost(host, PageRequest.of(0, 2));


### PR DESCRIPTION
## issue
- #40 

## 코드 설명
- 기존에 테스트코드의 픽스쳐는 `test1`, `test2`처럼 임의의 문자열로 네이밍을 했습니다. 이를 실제 서비스에서 사용될 데이터와 유사한 이름으로 수정하였습니다. 예를 들어 `Space` 데이터의 픽스쳐의 네임 필드는 `잠실`과 같은 이름을 사용하도록 변경하였습니다.
