### PR TITLE
[BE] 제출하기 API 를 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
@@ -4,7 +4,6 @@ import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.job.JobRepository;
-import com.woowacourse.gongcheck.domain.submission.Submission;
 import com.woowacourse.gongcheck.domain.submission.SubmissionRepository;
 import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.domain.task.RunningTasks;
@@ -13,7 +12,6 @@ import com.woowacourse.gongcheck.domain.task.Tasks;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,11 +50,7 @@ public class SubmissionService {
         RunningTasks runningTasks = new RunningTasks(runningTaskRepository.findAllById(tasks.getTaskIds()));
         validateRunning(tasks);
         validateCompletion(runningTasks);
-        submissionRepository.save(Submission.builder()
-                .job(job)
-                .author(request.getAuthor())
-                .createdAt(LocalDateTime.now())
-                .build());
+        submissionRepository.save(job.createSubmission(request.getAuthor()));
         runningTaskRepository.deleteAllByIdInBatch(tasks.getTaskIds());
     }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
@@ -1,0 +1,74 @@
+package com.woowacourse.gongcheck.application;
+
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.submission.Submission;
+import com.woowacourse.gongcheck.domain.submission.SubmissionRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTasks;
+import com.woowacourse.gongcheck.domain.task.TaskRepository;
+import com.woowacourse.gongcheck.domain.task.Tasks;
+import com.woowacourse.gongcheck.exception.BusinessException;
+import com.woowacourse.gongcheck.exception.NotFoundException;
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SubmissionService {
+
+    private final HostRepository hostRepository;
+    private final JobRepository jobRepository;
+    private final TaskRepository taskRepository;
+    private final RunningTaskRepository runningTaskRepository;
+    private final SubmissionRepository submissionRepository;
+
+    public SubmissionService(final HostRepository hostRepository, final JobRepository jobRepository,
+                             final TaskRepository taskRepository,
+                             final RunningTaskRepository runningTaskRepository,
+                             final SubmissionRepository submissionRepository) {
+        this.hostRepository = hostRepository;
+        this.jobRepository = jobRepository;
+        this.taskRepository = taskRepository;
+        this.runningTaskRepository = runningTaskRepository;
+        this.submissionRepository = submissionRepository;
+    }
+
+    @Transactional
+    public void submitJobCompletion(final Long hostId, final Long jobId, final SubmissionRequest request) {
+        Host host = hostRepository.findById(hostId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
+        Job job = jobRepository.findBySpaceHostAndId(host, jobId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 작업입니다."));
+        saveSubmissionAndClearRunningTasks(request, job);
+    }
+
+    private void saveSubmissionAndClearRunningTasks(final SubmissionRequest request, final Job job) {
+        Tasks tasks = new Tasks(taskRepository.findAllBySectionJob(job));
+        RunningTasks runningTasks = new RunningTasks(runningTaskRepository.findAllById(tasks.getTaskIds()));
+        validateRunning(tasks);
+        validateCompletion(runningTasks);
+        submissionRepository.save(Submission.builder()
+                .job(job)
+                .author(request.getAuthor())
+                .createdAt(LocalDateTime.now())
+                .build());
+        runningTaskRepository.deleteAllByIdInBatch(tasks.getTaskIds());
+    }
+
+    private void validateRunning(final Tasks tasks) {
+        if (!runningTaskRepository.existsByTaskIdIn(tasks.getTaskIds())) {
+            throw new BusinessException("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.");
+        }
+    }
+
+    private void validateCompletion(final RunningTasks runningTasks) {
+        if (!runningTasks.isAllChecked()) {
+            throw new BusinessException("모든 작업이 완료되지않아 제출이 불가합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/SubmissionService.java
@@ -47,9 +47,9 @@ public class SubmissionService {
 
     private void saveSubmissionAndClearRunningTasks(final SubmissionRequest request, final Job job) {
         Tasks tasks = new Tasks(taskRepository.findAllBySectionJob(job));
-        RunningTasks runningTasks = new RunningTasks(runningTaskRepository.findAllById(tasks.getTaskIds()));
         validateRunning(tasks);
-        validateCompletion(runningTasks);
+        RunningTasks runningTasks = new RunningTasks(runningTaskRepository.findAllById(tasks.getTaskIds()));
+        runningTasks.validateCompletion();
         submissionRepository.save(job.createSubmission(request.getAuthor()));
         runningTaskRepository.deleteAllByIdInBatch(tasks.getTaskIds());
     }
@@ -57,12 +57,6 @@ public class SubmissionService {
     private void validateRunning(final Tasks tasks) {
         if (!runningTaskRepository.existsByTaskIdIn(tasks.getTaskIds())) {
             throw new BusinessException("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.");
-        }
-    }
-
-    private void validateCompletion(final RunningTasks runningTasks) {
-        if (!runningTasks.isAllChecked()) {
-            throw new BusinessException("모든 작업이 완료되지않아 제출이 불가합니다.");
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/job/Job.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/job/Job.java
@@ -1,6 +1,7 @@
 package com.woowacourse.gongcheck.domain.job;
 
 import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.submission.Submission;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -49,6 +50,14 @@ public class Job {
         this.name = name;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    public Submission createSubmission(final String author) {
+        return Submission.builder()
+                .job(this)
+                .author(author)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
@@ -1,0 +1,19 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import java.util.List;
+
+public class RunningTasks {
+
+    private final List<RunningTask> runningTasks;
+
+    public RunningTasks(final List<RunningTask> runningTasks) {
+        this.runningTasks = runningTasks;
+    }
+
+    public boolean isAllChecked() {
+        return runningTasks.stream()
+                .filter(runningTask -> !runningTask.isChecked())
+                .findAny()
+                .isEmpty();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
@@ -1,5 +1,6 @@
 package com.woowacourse.gongcheck.domain.task;
 
+import com.woowacourse.gongcheck.exception.BusinessException;
 import java.util.List;
 
 public class RunningTasks {
@@ -10,7 +11,13 @@ public class RunningTasks {
         this.runningTasks = runningTasks;
     }
 
-    public boolean isAllChecked() {
+    public void validateCompletion() {
+        if (!isAllChecked()) {
+            throw new BusinessException("모든 작업이 완료되지않아 제출이 불가합니다.");
+        }
+    }
+
+    private boolean isAllChecked() {
         return runningTasks.stream()
                 .allMatch(RunningTask::isChecked);
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTasks.java
@@ -12,8 +12,6 @@ public class RunningTasks {
 
     public boolean isAllChecked() {
         return runningTasks.stream()
-                .filter(runningTask -> !runningTask.isChecked())
-                .findAny()
-                .isEmpty();
+                .allMatch(RunningTask::isChecked);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/SubmissionController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/SubmissionController.java
@@ -1,0 +1,30 @@
+package com.woowacourse.gongcheck.presentation;
+
+import com.woowacourse.gongcheck.application.SubmissionService;
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class SubmissionController {
+
+    private final SubmissionService submissionService;
+
+    public SubmissionController(final SubmissionService submissionService) {
+        this.submissionService = submissionService;
+    }
+
+    @PostMapping("/jobs/{jobId}/complete")
+    public ResponseEntity<Void> submitJobCompletion(@AuthenticationPrincipal final Long hostId,
+                                                    @PathVariable final Long jobId,
+                                                    @Valid @RequestBody final SubmissionRequest request) {
+        submissionService.submitJobCompletion(hostId, jobId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SubmissionRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SubmissionRequest.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class SubmissionRequest {
 
     @Size(min = 1, max = 20, message = "제출자 이름의 길이가 올바르지 않습니다.")
-    @NotNull
+    @NotNull(message = "제출자 이름은 null 일 수 없습니다.")
     private String author;
 
     private SubmissionRequest() {

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SubmissionRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SubmissionRequest.java
@@ -1,0 +1,20 @@
+package com.woowacourse.gongcheck.presentation.request;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SubmissionRequest {
+
+    @Size(min = 1, max = 20, message = "제출자 이름의 길이가 올바르지 않습니다.")
+    @NotNull
+    private String author;
+
+    private SubmissionRequest() {
+    }
+
+    public SubmissionRequest(final String author) {
+        this.author = author;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
@@ -1,0 +1,85 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class SubmissionAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 현재_진행중인_작업이_모두_완료된_상태로_제출한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+        새로운_진행작업을_생성한다(token);
+        체크박스를_체크한다(token, 1L);
+        체크박스를_체크한다(token, 2L);
+        SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 현재_진행중인_작업을_미완료_상태로_제출을_시도할_경우_실패한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+        새로운_진행작업을_생성한다(token);
+        체크박스를_체크한다(token, 1L);
+        SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(guestEnterRequest)
+                .when().post("/api/hosts/1/enter")
+                .then().log().all()
+                .extract()
+                .as(GuestTokenResponse.class)
+                .getToken();
+    }
+
+    private void 새로운_진행작업을_생성한다(final String token) {
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all();
+    }
+
+    private void 체크박스를_체크한다(final String token, final Long taskId) {
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/tasks/" + taskId)
+                .then().log().all();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
@@ -21,6 +21,8 @@ class SubmissionAcceptanceTest extends AcceptanceTest {
         새로운_진행작업을_생성한다(token);
         체크박스를_체크한다(token, 1L);
         체크박스를_체크한다(token, 2L);
+        체크박스를_체크한다(token, 3L);
+        체크박스를_체크한다(token, 4L);
         SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
 
         ExtractableResponse<Response> response = RestAssured
@@ -79,7 +81,7 @@ class SubmissionAcceptanceTest extends AcceptanceTest {
         RestAssured
                 .given().log().all()
                 .auth().oauth2(token)
-                .when().post("/api/tasks/" + taskId)
+                .when().post("/api/tasks/" + taskId + "/flip")
                 .then().log().all();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
@@ -130,6 +130,7 @@ class SubmissionServiceTest {
             checkAllRunningTasks(true);
 
             submissionService.submitJobCompletion(hostWithTasks.getId(), job.getId(), request);
+
             assertAll(
                     () -> assertThat(submissionRepository.findAll().size()).isEqualTo(1),
                     () -> assertThat(runningTaskRepository.findAll().size()).isEqualTo(0)

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
@@ -1,0 +1,164 @@
+package com.woowacourse.gongcheck.application;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.section.SectionRepository;
+import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import com.woowacourse.gongcheck.domain.submission.SubmissionRepository;
+import com.woowacourse.gongcheck.domain.task.RunningTask;
+import com.woowacourse.gongcheck.domain.task.RunningTaskRepository;
+import com.woowacourse.gongcheck.domain.task.Task;
+import com.woowacourse.gongcheck.domain.task.TaskRepository;
+import com.woowacourse.gongcheck.exception.BusinessException;
+import com.woowacourse.gongcheck.exception.NotFoundException;
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class SubmissionServiceTest {
+
+    @Autowired
+    private SubmissionService submissionService;
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private RunningTaskRepository runningTaskRepository;
+
+    @Autowired
+    private SubmissionRepository submissionRepository;
+
+    @Test
+    void 존재하지_않는_호스트로_제출을_시도할_경우_예외가_발생한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+
+        assertThatThrownBy(() -> submissionService.submitJobCompletion(0L, 1L, request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 호스트입니다.");
+    }
+
+    @Test
+    void 존재하지_않는_작업으로_제출을_시도할_경우_예외가_발생한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+        Host host = hostRepository.save(Host_생성("1234"));
+
+        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), 0L, request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 작업입니다.");
+    }
+
+    @Test
+    void 다른_호스트의_작업으로_제출을_시도할_경우_예외가_발생한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+        Host host1 = hostRepository.save(Host_생성("1234"));
+        Host host2 = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host2, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+
+        assertThatThrownBy(() -> submissionService.submitJobCompletion(host1.getId(), job.getId(), request))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 작업입니다.");
+    }
+
+    @Test
+    void 현재_진행중인_작업이_없는데_제출을_시도할_경우_예외가_발생한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+
+        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), job.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.");
+    }
+
+    @Test
+    void 현재_진행중인_작업을_미완료_상태로_제출을_시도할_경우_예외가_발생한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task1 = Task_생성(section, "책상 청소");
+        Task task2 = Task_생성(section, "의자 넣기");
+        taskRepository.saveAll(List.of(task1, task2));
+        RunningTask runningTask1 = RunningTask.builder()
+                .taskId(task1.getId())
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTask runningTask2 = RunningTask.builder()
+                .taskId(task1.getId())
+                .isChecked(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+        runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
+
+        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), job.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("모든 작업이 완료되지않아 제출이 불가합니다.");
+    }
+
+    @Test
+    void 현재_진행중인_작업이_모두_완료된_상태로_제출한다() {
+        SubmissionRequest request = new SubmissionRequest("제출자");
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task1 = Task_생성(section, "책상 청소");
+        Task task2 = Task_생성(section, "의자 넣기");
+        taskRepository.saveAll(List.of(task1, task2));
+        RunningTask runningTask1 = RunningTask.builder()
+                .taskId(task1.getId())
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTask runningTask2 = RunningTask.builder()
+                .taskId(task1.getId())
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
+
+        submissionService.submitJobCompletion(host.getId(), job.getId(), request);
+        assertAll(
+                () -> assertThat(submissionRepository.findAll().size()).isEqualTo(1),
+                () -> assertThat(runningTaskRepository.findAll().size()).isEqualTo(0)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.application;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
@@ -25,8 +26,9 @@ import com.woowacourse.gongcheck.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
-import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,105 +62,84 @@ class SubmissionServiceTest {
     @Autowired
     private SubmissionRepository submissionRepository;
 
-    @Test
-    void 존재하지_않는_호스트로_제출을_시도할_경우_예외가_발생한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
+    @Nested
+    class 제출_시도_시 {
 
-        assertThatThrownBy(() -> submissionService.submitJobCompletion(0L, 1L, request))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 호스트입니다.");
-    }
+        private final SubmissionRequest request = new SubmissionRequest("제출자");
 
-    @Test
-    void 존재하지_않는_작업으로_제출을_시도할_경우_예외가_발생한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
-        Host host = hostRepository.save(Host_생성("1234"));
+        private Host hostWithoutTasks;
+        private Host hostWithTasks;
+        private Space space;
+        private Job job;
+        private Section section;
+        private Task task1;
+        private Task task2;
 
-        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), 0L, request))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 작업입니다.");
-    }
+        @BeforeEach
+        void setUp() {
+            hostWithoutTasks = hostRepository.save(Host_생성("1234"));
+            hostWithTasks = hostRepository.save(Host_생성("1234"));
+            space = spaceRepository.save(Space_생성(hostWithTasks, "잠실"));
+            job = jobRepository.save(Job_생성(space, "청소"));
+            section = sectionRepository.save(Section_생성(job, "트랙룸"));
+            task1 = Task_생성(section, "책상 청소");
+            task2 = Task_생성(section, "의자 넣기");
+            taskRepository.saveAll(List.of(task1, task2));
+        }
 
-    @Test
-    void 다른_호스트의_작업으로_제출을_시도할_경우_예외가_발생한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
-        Space space = spaceRepository.save(Space_생성(host2, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "청소"));
+        @Test
+        void 호스트가_존재하지_않는_경우_예외가_발생한다() {
+            assertThatThrownBy(() -> submissionService.submitJobCompletion(0L, 1L, request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 호스트입니다.");
+        }
 
-        assertThatThrownBy(() -> submissionService.submitJobCompletion(host1.getId(), job.getId(), request))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessage("존재하지 않는 작업입니다.");
-    }
+        @Test
+        void 작업이_존재하지_않는_경우_예외가_발생한다() {
+            assertThatThrownBy(() -> submissionService.submitJobCompletion(hostWithTasks.getId(), 0L, request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 작업입니다.");
+        }
 
-    @Test
-    void 현재_진행중인_작업이_없는데_제출을_시도할_경우_예외가_발생한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
-        Host host = hostRepository.save(Host_생성("1234"));
-        Space space = spaceRepository.save(Space_생성(host, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "청소"));
-        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-        taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+        @Test
+        void 다른_호스트의_작업으로_제출을_시도할_경우_예외가_발생한다() {
+            assertThatThrownBy(
+                    () -> submissionService.submitJobCompletion(hostWithoutTasks.getId(), job.getId(), request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 작업입니다.");
+        }
 
-        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), job.getId(), request))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.");
-    }
+        @Test
+        void 현재_진행중인_작업이_없는데_제출을_시도할_경우_예외가_발생한다() {
+            assertThatThrownBy(() -> submissionService.submitJobCompletion(hostWithTasks.getId(), job.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.");
+        }
 
-    @Test
-    void 현재_진행중인_작업을_미완료_상태로_제출을_시도할_경우_예외가_발생한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
-        Host host = hostRepository.save(Host_생성("1234"));
-        Space space = spaceRepository.save(Space_생성(host, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "청소"));
-        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-        Task task1 = Task_생성(section, "책상 청소");
-        Task task2 = Task_생성(section, "의자 넣기");
-        taskRepository.saveAll(List.of(task1, task2));
-        RunningTask runningTask1 = RunningTask.builder()
-                .taskId(task1.getId())
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
-        RunningTask runningTask2 = RunningTask.builder()
-                .taskId(task1.getId())
-                .isChecked(false)
-                .createdAt(LocalDateTime.now())
-                .build();
-        runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
+        @Test
+        void 현재_진행중인_작업을_미완료_상태로_제출을_시도할_경우_예외가_발생한다() {
+            checkAllRunningTasks(false);
 
-        assertThatThrownBy(() -> submissionService.submitJobCompletion(host.getId(), job.getId(), request))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("모든 작업이 완료되지않아 제출이 불가합니다.");
-    }
+            assertThatThrownBy(() -> submissionService.submitJobCompletion(hostWithTasks.getId(), job.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("모든 작업이 완료되지않아 제출이 불가합니다.");
+        }
 
-    @Test
-    void 현재_진행중인_작업이_모두_완료된_상태로_제출한다() {
-        SubmissionRequest request = new SubmissionRequest("제출자");
-        Host host = hostRepository.save(Host_생성("1234"));
-        Space space = spaceRepository.save(Space_생성(host, "잠실"));
-        Job job = jobRepository.save(Job_생성(space, "청소"));
-        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-        Task task1 = Task_생성(section, "책상 청소");
-        Task task2 = Task_생성(section, "의자 넣기");
-        taskRepository.saveAll(List.of(task1, task2));
-        RunningTask runningTask1 = RunningTask.builder()
-                .taskId(task1.getId())
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
-        RunningTask runningTask2 = RunningTask.builder()
-                .taskId(task1.getId())
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
-        runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
+        @Test
+        void 현재_진행중인_작업이_모두_완료된_상태로_제출한다() {
+            checkAllRunningTasks(true);
 
-        submissionService.submitJobCompletion(host.getId(), job.getId(), request);
-        assertAll(
-                () -> assertThat(submissionRepository.findAll().size()).isEqualTo(1),
-                () -> assertThat(runningTaskRepository.findAll().size()).isEqualTo(0)
-        );
+            submissionService.submitJobCompletion(hostWithTasks.getId(), job.getId(), request);
+            assertAll(
+                    () -> assertThat(submissionRepository.findAll().size()).isEqualTo(1),
+                    () -> assertThat(runningTaskRepository.findAll().size()).isEqualTo(0)
+            );
+        }
+
+        private void checkAllRunningTasks(final boolean isChecked) {
+            RunningTask runningTask1 = RunningTask_생성(task1.getId(), true);
+            RunningTask runningTask2 = RunningTask_생성(task2.getId(), isChecked);
+            runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -103,7 +103,9 @@ class TaskServiceTest {
         Task task1 = Task_생성(section, "책상 청소");
         Task task2 = Task_생성(section, "의자 넣기");
         taskRepository.saveAll(List.of(task1, task2));
-        runningTaskRepository.saveAll(List.of(RunningTask_생성(task1), RunningTask_생성(task2)));
+        runningTaskRepository.saveAll(
+                List.of(RunningTask_생성(task1.getId(), true),
+                        RunningTask_생성(task2.getId(), true)));
 
         assertThatThrownBy(() -> taskService.createNewRunningTasks(host.getId(), job.getId()))
                 .isInstanceOf(BusinessException.class)
@@ -228,8 +230,8 @@ class TaskServiceTest {
         void 다른_호스트의_작업의_진행중인_작업을_조회하려는_경우_예외가_발생한다() {
             Host differentHost = hostRepository.save(Host_생성("1234"));
             taskRepository.saveAll(List.of(task1, task2));
-            RunningTask runningTask1 = RunningTask_생성(task1);
-            RunningTask runningTask2 = RunningTask_생성(task2);
+            RunningTask runningTask1 = RunningTask_생성(task1.getId(), false);
+            RunningTask runningTask2 = RunningTask_생성(task2.getId(), false);
             runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
             entityManager.flush();
             entityManager.clear();
@@ -251,8 +253,8 @@ class TaskServiceTest {
         @Test
         void 정상적으로_진행중인_작업을_조회한다() {
             taskRepository.saveAll(List.of(task1, task2));
-            RunningTask runningTask1 = RunningTask_생성(task1);
-            RunningTask runningTask2 = RunningTask_생성(task2);
+            RunningTask runningTask1 = RunningTask_생성(task1.getId(), false);
+            RunningTask runningTask2 = RunningTask_생성(task2.getId(), false);
             runningTaskRepository.saveAll(List.of(runningTask1, runningTask2));
             entityManager.flush();
             entityManager.clear();
@@ -292,8 +294,8 @@ class TaskServiceTest {
 
         taskRepository.save(task);
         taskRepository.save(differentTask);
-        runningTaskRepository.save(RunningTask_생성(task));
-        runningTaskRepository.save(RunningTask_생성(differentTask));
+        runningTaskRepository.save(RunningTask_생성(task.getId(), false));
+        runningTaskRepository.save(RunningTask_생성(differentTask.getId(), false));
 
         assertThatThrownBy(() -> taskService.flipRunningTask(differentHost.getId(), task.getId()))
                 .isInstanceOf(NotFoundException.class)
@@ -308,7 +310,7 @@ class TaskServiceTest {
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
         Task task = Task_생성(section, "책상 청소");
         taskRepository.save(task);
-        runningTaskRepository.save(RunningTask_생성(task));
+        runningTaskRepository.save(RunningTask_생성(task.getId(), false));
 
         assertThatThrownBy(() -> taskService.flipRunningTask(0L, task.getId()))
                 .isInstanceOf(NotFoundException.class)

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -7,11 +7,13 @@ import com.woowacourse.gongcheck.application.GuestAuthService;
 import com.woowacourse.gongcheck.application.JjwtTokenProvider;
 import com.woowacourse.gongcheck.application.JobService;
 import com.woowacourse.gongcheck.application.SpaceService;
+import com.woowacourse.gongcheck.application.SubmissionService;
 import com.woowacourse.gongcheck.application.TaskService;
 import com.woowacourse.gongcheck.presentation.AuthenticationContext;
 import com.woowacourse.gongcheck.presentation.GuestAuthController;
 import com.woowacourse.gongcheck.presentation.JobController;
 import com.woowacourse.gongcheck.presentation.SpaceController;
+import com.woowacourse.gongcheck.presentation.SubmissionController;
 import com.woowacourse.gongcheck.presentation.TaskController;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -28,7 +30,8 @@ import org.springframework.web.context.WebApplicationContext;
         GuestAuthController.class,
         SpaceController.class,
         JobController.class,
-        TaskController.class
+        TaskController.class,
+        SubmissionController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 class DocumentationTest {
@@ -46,6 +49,9 @@ class DocumentationTest {
 
     @MockBean
     protected TaskService taskService;
+
+    @MockBean
+    protected SubmissionService submissionService;
 
     @MockBean
     protected JjwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
@@ -1,0 +1,31 @@
+package com.woowacourse.gongcheck.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class SubmissionDocumentation extends DocumentationTest {
+
+    @Test
+    void 현재_진행중인_작업이_모두_완료된_상태로_제출한다() {
+        doNothing().when(submissionService).submitJobCompletion(anyLong(), anyLong(), any());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
+        docsGiven
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .apply(document("submissions/submit"))
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -61,8 +61,8 @@ class TaskDocumentation extends DocumentationTest {
         Job job = Job_생성(space, "청소");
         Section section1 = Section_아이디_지정_생성(1L, job, "트랙룸");
         Section section2 = Section_아이디_지정_생성(2L, job, "굿샷강의장");
-        RunningTask runningTask1 = RunningTask_생성(Task_생성(section1, "책상 청소"));
-        RunningTask runningTask2 = RunningTask_생성(Task_생성(section2, "책상 청소"));
+        RunningTask runningTask1 = RunningTask_생성(Task_생성(section1, "책상 청소").getId(), false);
+        RunningTask runningTask2 = RunningTask_생성(Task_생성(section2, "책상 청소").getId(), false);
         Task task1 = RunningTask로_Task_생성(runningTask1, section1, "책상 청소");
         Task task2 = RunningTask로_Task_생성(runningTask2, section2, "의자 청소");
         when(taskService.findRunningTasks(anyLong(), any())).thenReturn(

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
@@ -65,7 +65,7 @@ class RunningTaskRepositoryTest {
 
         @Test
         void 진행중인_테스크가_존재하는_경우_True를_반환한다() {
-            runningTaskRepository.save(RunningTask_생성(task));
+            runningTaskRepository.save(RunningTask_생성(task.getId(), false));
             boolean result = runningTaskRepository.existsByTaskIdIn(List.of(task.getId()));
 
             assertThat(result).isTrue();
@@ -87,7 +87,7 @@ class RunningTaskRepositoryTest {
 
         @Test
         void 진행중인_테스크가_존재하는_경우_테스크를_조회한다() {
-            runningTaskRepository.save(RunningTask_생성(task));
+            runningTaskRepository.save(RunningTask_생성(task.getId(), false));
             Optional<RunningTask> result = runningTaskRepository.findByTaskId(task.getId());
 
             assertThat(result).isNotEmpty();

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
@@ -1,8 +1,8 @@
 package com.woowacourse.gongcheck.domain.task;
 
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -10,16 +10,8 @@ class RunningTasksTest {
 
     @Test
     void 모든_테스크가_완료되었는지_확인한다() {
-        RunningTask runningTask1 = RunningTask.builder()
-                .taskId(1L)
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
-        RunningTask runningTask2 = RunningTask.builder()
-                .taskId(2L)
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
+        RunningTask runningTask1 = RunningTask_생성(1L, true);
+        RunningTask runningTask2 = RunningTask_생성(2L, true);
         RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
 
         assertThat(runningTasks.isAllChecked()).isTrue();
@@ -27,16 +19,8 @@ class RunningTasksTest {
 
     @Test
     void 테스크가_하나라도_미완료상태인지_확인한다() {
-        RunningTask runningTask1 = RunningTask.builder()
-                .taskId(1L)
-                .isChecked(true)
-                .createdAt(LocalDateTime.now())
-                .build();
-        RunningTask runningTask2 = RunningTask.builder()
-                .taskId(2L)
-                .isChecked(false)
-                .createdAt(LocalDateTime.now())
-                .build();
+        RunningTask runningTask1 = RunningTask_생성(1L, true);
+        RunningTask runningTask2 = RunningTask_생성(2L, false);
         RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
 
         assertThat(runningTasks.isAllChecked()).isFalse();

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
@@ -1,0 +1,44 @@
+package com.woowacourse.gongcheck.domain.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RunningTasksTest {
+
+    @Test
+    void 모든_테스크가_완료되었는지_확인한다() {
+        RunningTask runningTask1 = RunningTask.builder()
+                .taskId(1L)
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTask runningTask2 = RunningTask.builder()
+                .taskId(2L)
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
+
+        assertThat(runningTasks.isAllChecked()).isTrue();
+    }
+
+    @Test
+    void 테스크가_하나라도_미완료상태인지_확인한다() {
+        RunningTask runningTask1 = RunningTask.builder()
+                .taskId(1L)
+                .isChecked(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTask runningTask2 = RunningTask.builder()
+                .taskId(2L)
+                .isChecked(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+        RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
+
+        assertThat(runningTasks.isAllChecked()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTasksTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.gongcheck.domain.task;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.woowacourse.gongcheck.exception.BusinessException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +16,7 @@ class RunningTasksTest {
         RunningTask runningTask2 = RunningTask_생성(2L, true);
         RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
 
-        assertThat(runningTasks.isAllChecked()).isTrue();
+        assertDoesNotThrow(runningTasks::validateCompletion);
     }
 
     @Test
@@ -23,6 +25,8 @@ class RunningTasksTest {
         RunningTask runningTask2 = RunningTask_생성(2L, false);
         RunningTasks runningTasks = new RunningTasks(List.of(runningTask1, runningTask2));
 
-        assertThat(runningTasks.isAllChecked()).isFalse();
+        assertThatThrownBy(runningTasks::validateCompletion)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("모든 작업이 완료되지않아 제출이 불가합니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -66,14 +66,6 @@ public class FixtureFactory {
                 .build();
     }
 
-    public static RunningTask RunningTask_생성(final Task task) {
-        return RunningTask.builder()
-                .taskId(task.getId())
-                .isChecked(false)
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
-
     public static RunningTask RunningTask_생성(final Long taskId, final boolean isChecked) {
         return RunningTask.builder()
                 .taskId(taskId)

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/ControllerTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.presentation;
 
 import com.woowacourse.gongcheck.application.GuestAuthService;
 import com.woowacourse.gongcheck.application.JwtTokenProvider;
+import com.woowacourse.gongcheck.application.SubmissionService;
 import com.woowacourse.gongcheck.application.TaskService;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -13,7 +14,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 @WebMvcTest({
         GuestAuthController.class,
-        TaskController.class
+        TaskController.class,
+        SubmissionController.class
 })
 class ControllerTest {
 
@@ -24,6 +26,9 @@ class ControllerTest {
 
     @MockBean
     protected TaskService taskService;
+
+    @MockBean
+    protected SubmissionService submissionService;
 
     @MockBean
     protected AuthenticationContext authenticationContext;

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/SubmissionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/SubmissionControllerTest.java
@@ -13,6 +13,7 @@ import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
 import io.restassured.module.mockmvc.response.MockMvcResponse;
 import io.restassured.response.ExtractableResponse;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -24,7 +25,7 @@ class SubmissionControllerTest extends ControllerTest {
 
         SubmissionRequest submissionRequest = new SubmissionRequest("123456789123456789123");
         ExtractableResponse<MockMvcResponse> response = given
-                .header("Authorization", "Bearer jwt.token.here")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(submissionRequest)
                 .when().post("/api/jobs/1/complete")
@@ -44,7 +45,7 @@ class SubmissionControllerTest extends ControllerTest {
 
         SubmissionRequest submissionRequest = new SubmissionRequest(null);
         ExtractableResponse<MockMvcResponse> response = given
-                .header("Authorization", "Bearer jwt.token.here")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(submissionRequest)
                 .when().post("/api/jobs/1/complete")
@@ -67,7 +68,7 @@ class SubmissionControllerTest extends ControllerTest {
 
         SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
         ExtractableResponse<MockMvcResponse> response = given
-                .header("Authorization", "Bearer jwt.token.here")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(submissionRequest)
                 .when().post("/api/jobs/1/complete")
@@ -90,7 +91,7 @@ class SubmissionControllerTest extends ControllerTest {
 
         SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
         ExtractableResponse<MockMvcResponse> response = given
-                .header("Authorization", "Bearer jwt.token.here")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer jwt.token.here")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(submissionRequest)
                 .when().post("/api/jobs/1/complete")

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/SubmissionControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/SubmissionControllerTest.java
@@ -1,0 +1,106 @@
+package com.woowacourse.gongcheck.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.gongcheck.exception.BusinessException;
+import com.woowacourse.gongcheck.exception.ErrorResponse;
+import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
+import io.restassured.module.mockmvc.response.MockMvcResponse;
+import io.restassured.response.ExtractableResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class SubmissionControllerTest extends ControllerTest {
+
+    @Test
+    void 제출자_이름의_길이가_올바르지_않을_경우_예외가_발생한다() {
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        SubmissionRequest submissionRequest = new SubmissionRequest("123456789123456789123");
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.as(ErrorResponse.class).getMessage())
+                        .isEqualTo("제출자 이름의 길이가 올바르지 않습니다.")
+        );
+    }
+
+    @Test
+    void 제출자_이름이_null_일_경우_예외가_발생한다() {
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        SubmissionRequest submissionRequest = new SubmissionRequest(null);
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.as(ErrorResponse.class).getMessage())
+                        .isEqualTo("제출자 이름은 null 일 수 없습니다.")
+        );
+    }
+
+    @Test
+    void 현재_진행중인_작업이_없는데_제출을_시도할_경우_예외가_발생한다() {
+        doThrow(new BusinessException("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다."))
+                .when(submissionService)
+                .submitJobCompletion(anyLong(), anyLong(), any());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.as(ErrorResponse.class).getMessage())
+                        .isEqualTo("현재 제출할 수 있는 진행중인 작업이 존재하지 않습니다.")
+        );
+    }
+
+    @Test
+    void 현재_진행중인_작업을_미완료_상태로_제출을_시도할_경우_예외가_발생한다() {
+        doThrow(new BusinessException("모든 작업이 완료되지않아 제출이 불가합니다."))
+                .when(submissionService)
+                .submitJobCompletion(anyLong(), anyLong(), any());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        SubmissionRequest submissionRequest = new SubmissionRequest("제출자");
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(submissionRequest)
+                .when().post("/api/jobs/1/complete")
+                .then().log().all()
+                .extract();
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+                () -> assertThat(response.as(ErrorResponse.class).getMessage())
+                        .isEqualTo("모든 작업이 완료되지않아 제출이 불가합니다.")
+        );
+    }
+}


### PR DESCRIPTION
## issue
- #53 

## 코드 설명

### taskIds 로 컬럼이 allTrue 인지 확인할 방법은 없을까요?
전체 RunningTask 의 is_checked 컬럼이 true 인지 확인하기 위해 RunningTasks 라는 일급컬렉션을 만들어 모두 true 인지 확인하도록 구현했습니다. 개인적으론 조회 시에 컬럼이 모두 true 인지 boolean 으로 받아보고 싶은데 아직 방법을 찾지 못했네영..

### FixtureFactory 에 RunningTaskBuilder 에 taskId 랑 boolean 을 넣는 건 어떨까요?
```java
    public static RunningTask RunningTask_생성(final Long taskId, final boolean isChecked) {
        return RunningTask.builder()
                .taskId(taskId)
                .isChecked(isChecked)
                .createdAt(LocalDateTime.now())
                .build();
    }
```
RunningTask 의 체크 여부를 판단하기 위한 테스트를 만드는 도중 픽스처가 Task 를 받는 것으로 한정되어 있더라구요. 개인적으론 엔티티도 taskId 를 필드로 가지고 있고 체크 여부를 설정할 수 있게끔 위처럼 수정하면 범용적으로 사용할 수 있을 것 같다고 생각했습니다.

### 기존 API 명세에서 제출 요청 시 Author 바디가 없어서 추가했습니다.
```java
POST /api/jobs/{jobId}/complete HTTP/1.1
Authorization : Bearer jwt.token.here
{
  "author": "제출자"
}
```

### 인수테스트 미완성
인수테스트 시나리오를 구성하기 위해선 체크하기 API 가 필요하더라구요. 일단 코드는 추가해두어서 추후에 병합되면 테스트 통과할 것 같습니다.