### PR TITLE
[BE] 진행중인 작업을 조회하는 API를 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTaskResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTaskResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.gongcheck.application.response;
+
+import com.woowacourse.gongcheck.domain.task.Task;
+import lombok.Getter;
+
+@Getter
+public class RunningTaskResponse {
+
+    private Long id;
+    private String name;
+    private Boolean checked;
+
+    private RunningTaskResponse() {
+    }
+
+    private RunningTaskResponse(final Long id, final String name, final Boolean checked) {
+        this.id = id;
+        this.name = name;
+        this.checked = checked;
+    }
+
+    public static RunningTaskResponse from(final Task task) {
+        return new RunningTaskResponse(task.getId(), task.getName(), task.getRunningTask().isChecked());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTaskResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTaskResponse.java
@@ -8,7 +8,7 @@ public class RunningTaskResponse {
 
     private Long id;
     private String name;
-    private Boolean checked;
+    private boolean checked;
 
     private RunningTaskResponse() {
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTasksResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTasksResponse.java
@@ -1,0 +1,23 @@
+package com.woowacourse.gongcheck.application.response;
+
+import com.woowacourse.gongcheck.domain.task.Tasks;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class RunningTasksResponse {
+
+    private List<RunningTasksWithSectionResponse> sections;
+
+    private RunningTasksResponse() {
+    }
+
+    private RunningTasksResponse(
+            final List<RunningTasksWithSectionResponse> sections) {
+        this.sections = sections;
+    }
+
+    public static RunningTasksResponse from(final Tasks tasks) {
+        return new RunningTasksResponse(RunningTasksWithSectionResponse.from(tasks));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTasksWithSectionResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/RunningTasksWithSectionResponse.java
@@ -1,0 +1,45 @@
+package com.woowacourse.gongcheck.application.response;
+
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.task.Task;
+import com.woowacourse.gongcheck.domain.task.Tasks;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class RunningTasksWithSectionResponse {
+
+    private Long id;
+    private String name;
+    private List<RunningTaskResponse> tasks;
+
+    private RunningTasksWithSectionResponse() {
+    }
+
+    private RunningTasksWithSectionResponse(final Long id, final String name,
+                                            final List<RunningTaskResponse> tasks) {
+        this.id = id;
+        this.name = name;
+        this.tasks = tasks;
+    }
+
+    public static List<RunningTasksWithSectionResponse> from(final Tasks tasks) {
+        Map<Section, List<Task>> map = tasks.getTasks()
+                .stream()
+                .collect(Collectors.groupingBy(Task::getSection));
+
+        return map.entrySet()
+                .stream()
+                .map(entry -> RunningTasksWithSectionResponse.of(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private static RunningTasksWithSectionResponse of(final Section section, final List<Task> tasks) {
+        return new RunningTasksWithSectionResponse(section.getId(), section.getName(),
+                tasks.stream()
+                        .map(RunningTaskResponse::from)
+                        .collect(Collectors.toList()));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
@@ -39,8 +39,9 @@ public class RunningTask {
     }
 
     @Builder
-    public RunningTask(Long taskId, boolean isChecked, LocalDateTime createdAt) {
+    public RunningTask(Long taskId, Task task, boolean isChecked, LocalDateTime createdAt) {
         this.taskId = taskId;
+        this.task = task;
         this.isChecked = isChecked;
         this.createdAt = createdAt;
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
@@ -11,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,9 @@ public class Task {
     @JoinColumn(name = "section_id", nullable = false)
     private Section section;
 
+    @OneToOne(mappedBy = "task", fetch = FetchType.LAZY)
+    private RunningTask runningTask;
+
     @Column(name = "name", length = NAME_MAX_LENGTH, nullable = false)
     private String name;
 
@@ -43,9 +47,12 @@ public class Task {
     }
 
     @Builder
-    public Task(Long id, Section section, String name, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public Task(Long id, Section section, RunningTask runningTask, String name,
+                LocalDateTime createdAt,
+                LocalDateTime updatedAt) {
         this.id = id;
         this.section = section;
+        this.runningTask = runningTask;
         this.name = name;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
@@ -4,10 +4,13 @@ import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.job.Job;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
+    @EntityGraph(attributePaths = {"runningTask"}, type = EntityGraphType.FETCH)
     List<Task> findAllBySectionJob(final Job job);
 
     Optional<Task> findBySectionJobSpaceHostAndId(final Host host, final Long taskId);

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Tasks.java
@@ -3,7 +3,9 @@ package com.woowacourse.gongcheck.domain.task;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.Getter;
 
+@Getter
 public class Tasks {
 
     private final List<Task> tasks;

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/TaskController.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.presentation;
 
 import com.woowacourse.gongcheck.application.TaskService;
 import com.woowacourse.gongcheck.application.response.JobActiveResponse;
+import com.woowacourse.gongcheck.application.response.RunningTasksResponse;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +32,13 @@ public class TaskController {
     public ResponseEntity<JobActiveResponse> isJobActive(@AuthenticationPrincipal final Long hostId,
                                                          @PathVariable final Long jobId) {
         JobActiveResponse response = taskService.isJobActivated(hostId, jobId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/jobs/{jobId}/tasks")
+    public ResponseEntity<RunningTasksResponse> showRunningTasks(@AuthenticationPrincipal final Long hostId,
+                                                                 @PathVariable final Long jobId) {
+        RunningTasksResponse response = taskService.findRunningTasks(hostId, jobId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.gongcheck.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.application.response.RunningTasksResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -51,6 +53,31 @@ class TaskAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 진행중인_작업을_조회한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+        RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().post("/api/jobs/1/tasks/new")
+                .then().log().all()
+                .extract();
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().get("/api/jobs/1/tasks")
+                .then().log().all()
+                .extract();
+        RunningTasksResponse runningTasksResponse = response.as(RunningTasksResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(runningTasksResponse.getSections()).hasSize(2)
+        );
+    }
+
+    @Test
     void 진행_작업을_생성하고_작업의_진행여부를_확인한다() {
         GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
         String token = 토큰을_요청한다(guestEnterRequest);
@@ -85,6 +112,21 @@ class TaskAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+    
+    @Test
+    void 진행중인_작업이_존재하지_않는데_조회할_경우_예외가_발생한다() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().get("/api/jobs/1/tasks")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -1,5 +1,12 @@
 package com.woowacourse.gongcheck.documentation;
 
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask로_Task_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_아이디_지정_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -7,6 +14,15 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 import com.woowacourse.gongcheck.application.response.JobActiveResponse;
+import com.woowacourse.gongcheck.application.response.RunningTasksResponse;
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.section.Section;
+import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.task.RunningTask;
+import com.woowacourse.gongcheck.domain.task.Task;
+import com.woowacourse.gongcheck.domain.task.Tasks;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -35,6 +51,30 @@ class TaskDocumentation extends DocumentationTest {
                 .when().get("/api/jobs/1/active")
                 .then().log().all()
                 .apply(document("tasks/active"))
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 진행중인_작업_조회() {
+        Host host = Host_생성("1234");
+        Space space = Space_생성(host, "잠실");
+        Job job = Job_생성(space, "청소");
+        Section section1 = Section_아이디_지정_생성(1L, job, "트랙룸");
+        Section section2 = Section_아이디_지정_생성(2L, job, "굿샷강의장");
+        RunningTask runningTask1 = RunningTask_생성(Task_생성(section1, "책상 청소"));
+        RunningTask runningTask2 = RunningTask_생성(Task_생성(section2, "책상 청소"));
+        Task task1 = RunningTask로_Task_생성(runningTask1, section1, "책상 청소");
+        Task task2 = RunningTask로_Task_생성(runningTask2, section2, "의자 청소");
+        when(taskService.findRunningTasks(anyLong(), any())).thenReturn(
+                RunningTasksResponse.from(new Tasks(List.of(task1, task2)))
+        );
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        docsGiven
+                .header("Authorization", "Bearer jwt.token.here")
+                .when().get("/api/jobs/1/tasks")
+                .then().log().all()
+                .apply(document("tasks/find"))
                 .statusCode(HttpStatus.OK.value());
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -40,9 +40,27 @@ public class FixtureFactory {
                 .build();
     }
 
+    public static Section Section_아이디_지정_생성(final Long id, final Job job, final String name) {
+        return Section.builder()
+                .id(id)
+                .job(job)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
     public static Task Task_생성(final Section section, final String name) {
         return Task.builder()
                 .section(section)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Task RunningTask로_Task_생성(final RunningTask runningTask, final Section section, final String name) {
+        return Task.builder()
+                .section(section)
+                .runningTask(runningTask)
                 .name(name)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/presentation/TaskControllerTest.java
@@ -32,6 +32,22 @@ class TaskControllerTest extends ControllerTest {
     }
 
     @Test
+    void 존재하는_진행작업이_없는데_조회하는_경우_예외가_발생한다() {
+        doThrow(new BusinessException("현재 진행중인 작업이 존재하지 않아 조회할 수 없습니다")).when(taskService)
+                .findRunningTasks(anyLong(), anyLong());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        ExtractableResponse<MockMvcResponse> response = given
+                .header("Authorization", "Bearer jwt.token.here")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/jobs/1/tasks")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
     void 진행중인_작업이_없는_경우_예외가_발생한다() {
         doThrow(new BusinessException("현재 진행 중인 작업이 아닙니다.")).when(taskService)
                 .flipRunningTask(anyLong(), anyLong());


### PR DESCRIPTION
## issue
- #54 

## 코드 설명
### 실행과정

```
1. Host를 찾는다 (host가 존재하지 않으면 예외 발생)
2. Job을 찾는다 (host와 jobid가 일치하지 않으면 예외 발생)
3. Job이 가지고있는 Tasks를 찾는다
4. 해당 Tasks중 RunningTask를 가진 Task가 없으면 예외를 발생시킨다
5. RunningTask를 가진 Task가 존재한다면 진행중인 작업이 있는 것이므로 Tasks로 RunningTasksResponse를 만들어 반환한다.
```

### 문제 상황
현재 RunningTask들을 조회하기 위해선 TaskId를 통해 조회해야 합니다.
이 행위가 부자연스러울 뿐더러 Task와 RunningTask가 거의 비슷하기 때문에 Task로 RunningTask를 조회하고 다시 RunningTask 부터 객체탐색을 시작하는 것이 비효율적으로 느껴집니다. 어차피 Task -> RunningTask 참조가 생겨도 조회만 할 것 이기 때문에 Task에 RunningTask 필드를 추가하였습니다.

### 코드 변경 사항
1. 전에 삭제한 @MapsId를 이용한 Task 필드를 다시 복구하였습니다.
```java
@MapsId("taskId")
@OneToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "task_id", nullable = false)
private Task task;
```
2. Task에도 RunningTask 연관관계 매핑을 추가하였습니다. 이와 동시에 N+1 쿼리 문제를 해결하기 위해 @EntityGraph를 사용했습니다.
```java
public class Task {

    @OneToOne(mappedBy = "task", fetch = FetchType.LAZY)
    private RunningTask runningTask;
}

public interface TaskRepository extends JpaRepository<Task, Long> {

    @EntityGraph(attributePaths = {"runningTask"}, type = EntityGraphType.FETCH)
    List<Task> findAllBySectionJob(final Job job);
}