### PR TITLE
[BE] 로컬환경을 위한 CORS에 대한 권한을 해제한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
@@ -4,12 +4,16 @@ import com.woowacourse.gongcheck.presentation.AuthenticationInterceptor;
 import com.woowacourse.gongcheck.presentation.AuthenticationPrincipalArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
 
     private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
     private final AuthenticationInterceptor authenticationInterceptor;
@@ -18,6 +22,13 @@ public class WebConfig implements WebMvcConfigurer {
                      final AuthenticationInterceptor authenticationInterceptor) {
         this.authenticationPrincipalArgumentResolver = authenticationPrincipalArgumentResolver;
         this.authenticationInterceptor = authenticationInterceptor;
+    }
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+                .exposedHeaders(HttpHeaders.LOCATION);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationInterceptor.java
@@ -6,6 +6,7 @@ import com.woowacourse.gongcheck.support.AuthorizationTokenExtractor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -23,6 +24,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
             throws Exception {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
         String token = AuthorizationTokenExtractor.extractToken(request)
                 .orElseThrow(() -> new UnauthorizedException("헤더에 토큰 값이 정상적으로 존재하지 않습니다."));
 


### PR DESCRIPTION
## issue
- #65 

## 코드 설명
- `AuthenticationInterceptor`에서 OPTION method로 들어온 요청에 대한 허용
- configuration 내에서 모든 method에 대한 cors 해제
