### PR TITLE
[BE] 인수테스트 내 중복되는 토큰 요청 메서드를 분리한다.

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AuthSupport.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AuthSupport.java
@@ -1,0 +1,21 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
+import io.restassured.RestAssured;
+import org.springframework.http.MediaType;
+
+public class AuthSupport {
+
+    public static String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(guestEnterRequest)
+                .when().post("/api/hosts/1/enter")
+                .then().log().all()
+                .extract()
+                .as(GuestTokenResponse.class)
+                .getToken();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/JobAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/JobAcceptanceTest.java
@@ -1,15 +1,14 @@
 package com.woowacourse.gongcheck.acceptance;
 
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 class JobAcceptanceTest extends AcceptanceTest {
 
@@ -26,17 +25,5 @@ class JobAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(guestEnterRequest)
-                .when().post("/api/hosts/1/enter")
-                .then().log().all()
-                .extract()
-                .as(GuestTokenResponse.class)
-                .getToken();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
@@ -1,15 +1,14 @@
 package com.woowacourse.gongcheck.acceptance;
 
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 class SpaceAcceptanceTest extends AcceptanceTest {
 
@@ -26,17 +25,5 @@ class SpaceAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(guestEnterRequest)
-                .when().post("/api/hosts/1/enter")
-                .then().log().all()
-                .extract()
-                .as(GuestTokenResponse.class)
-                .getToken();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SubmissionAcceptanceTest.java
@@ -1,8 +1,8 @@
 package com.woowacourse.gongcheck.acceptance;
 
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import com.woowacourse.gongcheck.presentation.request.SubmissionRequest;
 import io.restassured.RestAssured;
@@ -55,18 +55,6 @@ class SubmissionAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(guestEnterRequest)
-                .when().post("/api/hosts/1/enter")
-                .then().log().all()
-                .extract()
-                .as(GuestTokenResponse.class)
-                .getToken();
     }
 
     private void 새로운_진행작업을_생성한다(final String token) {

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/TaskAcceptanceTest.java
@@ -1,9 +1,9 @@
 package com.woowacourse.gongcheck.acceptance;
 
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.application.response.RunningTasksResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import io.restassured.RestAssured;
@@ -11,7 +11,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 class TaskAcceptanceTest extends AcceptanceTest {
 
@@ -163,17 +162,5 @@ class TaskAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    private String 토큰을_요청한다(final GuestEnterRequest guestEnterRequest) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(guestEnterRequest)
-                .when().post("/api/hosts/1/enter")
-                .then().log().all()
-                .extract()
-                .as(GuestTokenResponse.class)
-                .getToken();
     }
 }


### PR DESCRIPTION
## issue
- #42 

## 코드 설명
- 기존에 `GuestAuthAcceptanceTest` 를 제외한 모든 인수테스트에서 중복되는 메서드를 사용하고 있었기에, 이를 다른 클래스로 분리하여 static 으로 선언 후 import 하여 사용하도록 변경하였습니다.
