### PR TITLE
[BE] 테스트 픽스쳐 생성 시 id값을 직접 넣을 수 있도록 변경한다.

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -1,7 +1,7 @@
 package com.woowacourse.gongcheck.documentation;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_아이디_지정_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -27,8 +27,8 @@ class JobDocumentation extends DocumentationTest {
             Space space = Space_생성(host, "잠실");
             when(jobService.findPage(anyLong(), anyLong(), any())).thenReturn(
                     JobsResponse.of(List.of(
-                                    Job_생성(space, "청소"),
-                                    Job_생성(space, "마감")),
+                            Job_아이디_지정_생성(1L, space, "청소"),
+                            Job_아이디_지정_생성(2L, space, "마감")),
                             true)
             );
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -1,7 +1,7 @@
 package com.woowacourse.gongcheck.documentation;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_아이디_지정_생성;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -24,8 +24,8 @@ class SpaceDocumentation extends DocumentationTest {
             Host host = Host_생성("1234");
             when(spaceService.findPage(anyLong(), any())).thenReturn(
                     SpacesResponse.of(List.of(
-                                    Space_생성(host, "잠실"),
-                                    Space_생성(host, "선릉")),
+                            Space_아이디_지정_생성(1L, host, "잠실"),
+                            Space_아이디_지정_생성(2L, host, "선릉")),
                             true)
             );
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -3,7 +3,7 @@ package com.woowacourse.gongcheck.documentation;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask로_Task_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask로_Task_아이디_지정_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_아이디_지정_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
@@ -98,9 +98,9 @@ class TaskDocumentation extends DocumentationTest {
             Section section1 = Section_아이디_지정_생성(1L, job, "트랙룸");
             Section section2 = Section_아이디_지정_생성(2L, job, "굿샷강의장");
             RunningTask runningTask1 = RunningTask_생성(Task_생성(section1, "책상 청소").getId(), false);
-            RunningTask runningTask2 = RunningTask_생성(Task_생성(section2, "책상 청소").getId(), false);
-            Task task1 = RunningTask로_Task_생성(runningTask1, section1, "책상 청소");
-            Task task2 = RunningTask로_Task_생성(runningTask2, section2, "의자 청소");
+            RunningTask runningTask2 = RunningTask_생성(Task_생성(section2, "책상 청소").getId(), true);
+            Task task1 = RunningTask로_Task_아이디_지정_생성(1L, runningTask1, section1, "책상 청소");
+            Task task2 = RunningTask로_Task_아이디_지정_생성(2L, runningTask2, section2, "의자 청소");
             when(taskService.findRunningTasks(anyLong(), any())).thenReturn(
                     RunningTasksResponse.from(new Tasks(List.of(task1, task2)))
             );

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -24,8 +24,26 @@ public class FixtureFactory {
                 .build();
     }
 
+    public static Space Space_아이디_지정_생성(final Long id, final Host host, final String name) {
+        return Space.builder()
+                .id(id)
+                .host(host)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
     public static Job Job_생성(final Space space, final String name) {
         return Job.builder()
+                .space(space)
+                .name(name)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Job Job_아이디_지정_생성(final Long id, final Space space, final String name) {
+        return Job.builder()
+                .id(id)
                 .space(space)
                 .name(name)
                 .createdAt(LocalDateTime.now())
@@ -57,8 +75,9 @@ public class FixtureFactory {
                 .build();
     }
 
-    public static Task RunningTask로_Task_생성(final RunningTask runningTask, final Section section, final String name) {
+    public static Task RunningTask로_Task_아이디_지정_생성(final Long id, final RunningTask runningTask, final Section section, final String name) {
         return Task.builder()
+                .id(id)
                 .section(section)
                 .runningTask(runningTask)
                 .name(name)


### PR DESCRIPTION
## issue
- resolve #41

## 코드 설명
- documentation test에서 Service에 대한 mocking return값이 null이 들어오는 부분을 직접 id값을 입력받도록 수정
