### PR TITLE
[BE] Github Oauth 로그인 기능을 구현한다.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "backend/submodule"]
+	path = backend/submodule
+	url = https://github.com/gong-check/submodule.git
+    branch = main

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,7 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-!**/application-oauth.yml
+application-oauth.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+!**/application-oauth.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,13 @@ dependencies {
     implementation 'com.slack.api:slack-api-model:1.22.2'
 }
 
+processResources.dependsOn('copySecret')
+
+task copySecret(type: Copy) {
+    from '../backend/submodule/application-oauth.yml'
+    into 'src/main/resources'
+}
+
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
@@ -65,8 +72,8 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
     configurations 'asciidoctorExtensions'
-    sources{
-        include("**/index.adoc","**/common/*.adoc")
+    sources {
+        include("**/index.adoc", "**/common/*.adoc")
     }
     baseDirFollowsSourceFile()
     inputs.dir snippetsDir

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -67,7 +67,7 @@ public class GithubOauthClient {
             return restTemplate
                     .exchange(url, httpMethod, httpEntity, exchangeType)
                     .getBody();
-        } catch (HttpClientErrorException e) {
+        } catch (HttpClientErrorException | NullPointerException e) {
             throw new NotFoundException("해당 사용자의 프로필을 요청할 수 없습니다.");
         }
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -37,7 +37,7 @@ public class GithubOauthClient {
         this.restTemplate = restTemplate;
     }
 
-    public String requestAccessToken(String code) {
+    public String requestAccessToken(final String code) {
         GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(code, clientId, clientSecret);
 
         HttpHeaders headers = new HttpHeaders();
@@ -54,7 +54,7 @@ public class GithubOauthClient {
         return accessToken;
     }
 
-    public GithubProfileResponse requestGithubProfile(String accessToken) {
+    public GithubProfileResponse requestGithubProfile(final String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken);
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -1,0 +1,64 @@
+package com.woowacourse.gongcheck.application;
+
+import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
+import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.exception.UnauthorizedException;
+import com.woowacourse.gongcheck.presentation.request.GithubAccessTokenRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GithubOauthClient {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String tokenUrl;
+    private final String profileUrl;
+    private final RestTemplate restTemplate;
+
+    public GithubOauthClient(@Value("${github.client.id}") final String clientId,
+                             @Value("${github.client.secret}") final String clientSecret,
+                             @Value("${github.url.token}") final String tokenUrl,
+                             @Value("${github.url.profile}") final String profileUrl,
+                             final RestTemplate restTemplate) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.tokenUrl = tokenUrl;
+        this.profileUrl = profileUrl;
+        this.restTemplate = restTemplate;
+    }
+
+    public String requestAccessToken(String code) {
+        GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(code, clientId, clientSecret);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(githubAccessTokenRequest, headers);
+
+        String accessToken = restTemplate
+                .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
+                .getBody()
+                .getAccessToken();
+        if (accessToken == null) {
+            throw new UnauthorizedException("잘못된 요청입니다.");
+        }
+        return accessToken;
+    }
+
+    public GithubProfileResponse requestGithubProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate
+                .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
+                .getBody();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -4,6 +4,7 @@ import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
 import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
 import com.woowacourse.gongcheck.presentation.request.GithubAccessTokenRequest;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -16,8 +17,6 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class GithubOauthClient {
 
-    private static final String ACCEPT_HEADER = "Accept";
-    private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_TYPE = "Bearer ";
 
     private final String clientId;
@@ -42,14 +41,14 @@ public class GithubOauthClient {
         GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(code, clientId, clientSecret);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add(ACCEPT_HEADER, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
         HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(githubAccessTokenRequest, headers);
 
         String accessToken = restTemplate
                 .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
                 .getBody()
                 .getAccessToken();
-        if (accessToken == null) {
+        if (Objects.isNull(accessToken)) {
             throw new UnauthorizedException("잘못된 요청입니다.");
         }
         return accessToken;
@@ -57,7 +56,7 @@ public class GithubOauthClient {
 
     public GithubProfileResponse requestGithubProfile(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add(AUTHORIZATION_HEADER, BEARER_TYPE + accessToken);
+        headers.add(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken);
 
         HttpEntity httpEntity = new HttpEntity<>(headers);
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -16,6 +16,10 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class GithubOauthClient {
 
+    private static final String ACCEPT_HEADER = "Accept";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_TYPE = "Bearer ";
+
     private final String clientId;
     private final String clientSecret;
     private final String tokenUrl;
@@ -38,7 +42,7 @@ public class GithubOauthClient {
         GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(code, clientId, clientSecret);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.add(ACCEPT_HEADER, MediaType.APPLICATION_JSON_VALUE);
         HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(githubAccessTokenRequest, headers);
 
         String accessToken = restTemplate
@@ -53,7 +57,7 @@ public class GithubOauthClient {
 
     public GithubProfileResponse requestGithubProfile(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add(AUTHORIZATION_HEADER, BEARER_TYPE + accessToken);
 
         HttpEntity httpEntity = new HttpEntity<>(headers);
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -45,9 +45,7 @@ public class GithubOauthClient {
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
         HttpEntity<?> httpEntity = new HttpEntity<>(githubAccessTokenRequest, headers);
 
-        String accessToken = restTemplate
-                .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
-                .getBody()
+        String accessToken = exchangeRestTemplateBody(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
                 .getAccessToken();
         if (Objects.isNull(accessToken)) {
             throw new UnauthorizedException("잘못된 요청입니다.");
@@ -60,10 +58,14 @@ public class GithubOauthClient {
         headers.add(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken);
 
         HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+        return exchangeRestTemplateBody(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class);
+    }
 
+    private <T> T exchangeRestTemplateBody(final String url, final HttpMethod httpMethod,
+                                           final HttpEntity<?> httpEntity, final Class<T> exchangeType) {
         try {
             return restTemplate
-                    .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
+                    .exchange(url, httpMethod, httpEntity, exchangeType)
                     .getBody();
         } catch (HttpClientErrorException e) {
             throw new NotFoundException("해당 사용자의 프로필을 요청할 수 없습니다.");

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -44,7 +43,7 @@ public class GithubOauthClient {
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
-        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity(githubAccessTokenRequest, headers);
+        HttpEntity<?> httpEntity = new HttpEntity<>(githubAccessTokenRequest, headers);
 
         String accessToken = restTemplate
                 .exchange(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
@@ -60,7 +59,7 @@ public class GithubOauthClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION, BEARER_TYPE + accessToken);
 
-        HttpEntity httpEntity = new HttpEntity<>(headers);
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
 
         try {
             return restTemplate

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.application;
 
 import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
 import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.exception.NotFoundException;
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
 import com.woowacourse.gongcheck.presentation.request.GithubAccessTokenRequest;
 import java.util.Objects;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
@@ -60,8 +62,12 @@ public class GithubOauthClient {
 
         HttpEntity httpEntity = new HttpEntity<>(headers);
 
-        return restTemplate
-                .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
-                .getBody();
+        try {
+            return restTemplate
+                    .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
+                    .getBody();
+        } catch (HttpClientErrorException e) {
+            throw new NotFoundException("해당 사용자의 프로필을 요청할 수 없습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GithubOauthClient.java
@@ -45,12 +45,12 @@ public class GithubOauthClient {
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
         HttpEntity<?> httpEntity = new HttpEntity<>(githubAccessTokenRequest, headers);
 
-        String accessToken = exchangeRestTemplateBody(tokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
-                .getAccessToken();
-        if (Objects.isNull(accessToken)) {
+        GithubAccessTokenResponse githubAccessTokenResponse = exchangeRestTemplateBody(tokenUrl, HttpMethod.POST,
+                httpEntity, GithubAccessTokenResponse.class);
+        if (Objects.isNull(githubAccessTokenResponse)) {
             throw new UnauthorizedException("잘못된 요청입니다.");
         }
-        return accessToken;
+        return githubAccessTokenResponse.getAccessToken();
     }
 
     public GithubProfileResponse requestGithubProfile(final String accessToken) {

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/GuestAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/GuestAuthService.java
@@ -1,5 +1,7 @@
 package com.woowacourse.gongcheck.application;
 
+import static com.woowacourse.gongcheck.presentation.Authority.GUEST;
+
 import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
@@ -24,7 +26,7 @@ public class GuestAuthService {
         Host host = hostRepository.getById(hostId);
         host.checkPassword(new SpacePassword(request.getPassword()));
 
-        String token = jwtTokenProvider.createToken(String.valueOf(hostId));
+        String token = jwtTokenProvider.createToken(String.valueOf(hostId), GUEST);
         return GuestTokenResponse.from(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
@@ -1,0 +1,45 @@
+package com.woowacourse.gongcheck.application;
+
+import static com.woowacourse.gongcheck.presentation.Authority.HOST;
+
+import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class HostAuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final GithubOauthClient githubOauthClient;
+    private final HostRepository hostRepository;
+
+    public HostAuthService(final JwtTokenProvider jwtTokenProvider,
+                           final GithubOauthClient githubOauthClient,
+                           final HostRepository hostRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.githubOauthClient = githubOauthClient;
+        this.hostRepository = hostRepository;
+    }
+
+    @Transactional
+    public TokenResponse createToken(final TokenRequest tokenRequest) {
+        String accessToken = githubOauthClient.requestAccessToken(tokenRequest.getCode());
+        GithubProfileResponse githubProfileResponse = githubOauthClient.requestGithubProfile(accessToken);
+        boolean existHost = hostRepository.existsByGithubId(githubProfileResponse.getGithubId());
+        Host host = findOrCreateHost(existHost, githubProfileResponse);
+        String token = jwtTokenProvider.createToken(String.valueOf(host.getId()), HOST);
+        return TokenResponse.of(token, existHost);
+    }
+
+    private Host findOrCreateHost(final boolean existHost, final GithubProfileResponse githubProfileResponse) {
+        if (existHost) {
+            return hostRepository.getByGithubId(githubProfileResponse.getGithubId());
+        }
+        return hostRepository.save(githubProfileResponse.toHost());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
@@ -27,8 +27,8 @@ public class HostAuthService {
     }
 
     @Transactional
-    public TokenResponse createToken(final TokenRequest tokenRequest) {
-        String accessToken = githubOauthClient.requestAccessToken(tokenRequest.getCode());
+    public TokenResponse createToken(final TokenRequest request) {
+        String accessToken = githubOauthClient.requestAccessToken(request.getCode());
         GithubProfileResponse githubProfileResponse = githubOauthClient.requestGithubProfile(accessToken);
         boolean existHost = hostRepository.existsByGithubId(githubProfileResponse.getGithubId());
         Host host = findOrCreateHost(existHost, githubProfileResponse);

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
@@ -29,14 +29,14 @@ public class HostAuthService {
     public TokenResponse createToken(final TokenRequest request) {
         String accessToken = githubOauthClient.requestAccessToken(request.getCode());
         GithubProfileResponse githubProfileResponse = githubOauthClient.requestGithubProfile(accessToken);
-        boolean existHost = hostRepository.existsByGithubId(githubProfileResponse.getGithubId());
-        Host host = findOrCreateHost(existHost, githubProfileResponse);
+        boolean alreadyJoin = hostRepository.existsByGithubId(githubProfileResponse.getGithubId());
+        Host host = findOrCreateHost(alreadyJoin, githubProfileResponse);
         String token = jwtTokenProvider.createToken(String.valueOf(host.getId()), HOST);
-        return TokenResponse.of(token, existHost);
+        return TokenResponse.of(token, alreadyJoin);
     }
 
-    private Host findOrCreateHost(final boolean existHost, final GithubProfileResponse githubProfileResponse) {
-        if (existHost) {
+    private Host findOrCreateHost(final boolean alreadyJoin, final GithubProfileResponse githubProfileResponse) {
+        if (alreadyJoin) {
             return hostRepository.getByGithubId(githubProfileResponse.getGithubId());
         }
         return hostRepository.save(githubProfileResponse.toHost());

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostAuthService.java
@@ -18,8 +18,7 @@ public class HostAuthService {
     private final GithubOauthClient githubOauthClient;
     private final HostRepository hostRepository;
 
-    public HostAuthService(final JwtTokenProvider jwtTokenProvider,
-                           final GithubOauthClient githubOauthClient,
+    public HostAuthService(final JwtTokenProvider jwtTokenProvider, final GithubOauthClient githubOauthClient,
                            final HostRepository hostRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.githubOauthClient = githubOauthClient;

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/JjwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/JjwtTokenProvider.java
@@ -48,7 +48,7 @@ public class JjwtTokenProvider implements JwtTokenProvider {
     }
 
     @Override
-    public Authority extractAuthority(final String token) {
+    public Authority extractAuthority(final String token) throws UnauthorizedException {
         String authority = extractBody(token).get(AUTHORITY, String.class);
         return Authority.valueOf(authority);
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/JjwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/JjwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.application;
 
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
 import com.woowacourse.gongcheck.presentation.Authority;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JjwtTokenProvider implements JwtTokenProvider {
+
+    private static final String AUTHORITY = "authority";
 
     private final Key key;
     private final long expireTime;
@@ -34,37 +37,29 @@ public class JjwtTokenProvider implements JwtTokenProvider {
                 .setSubject(subject)
                 .setIssuedAt(now)
                 .setExpiration(expireDate)
-                .claim("authority", authority)
+                .claim(AUTHORITY, authority)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
     @Override
     public String extractSubject(final String token) throws UnauthorizedException {
+        return extractBody(token).getSubject();
+    }
+
+    @Override
+    public Authority extractAuthority(final String token) {
+        String authority = extractBody(token).get(AUTHORITY, String.class);
+        return Authority.valueOf(authority);
+    }
+
+    private Claims extractBody(final String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(token)
-                    .getBody()
-                    .getSubject();
-        } catch (ExpiredJwtException e) {
-            throw new UnauthorizedException("만료된 토큰입니다.");
-        } catch (JwtException e) {
-            throw new UnauthorizedException("올바르지 않은 토큰입니다.");
-        }
-    }
-
-    @Override
-    public Authority extractAuthority(final String token) {
-        try {
-            String authority = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .get("authority", String.class);
-            return Authority.valueOf(authority);
+                    .getBody();
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException("만료된 토큰입니다.");
         } catch (JwtException e) {

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/JwtTokenProvider.java
@@ -8,5 +8,5 @@ public interface JwtTokenProvider {
 
     String extractSubject(final String token) throws UnauthorizedException;
 
-    Authority extractAuthority(final String token);
+    Authority extractAuthority(final String token) throws UnauthorizedException;
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/JwtTokenProvider.java
@@ -1,9 +1,12 @@
 package com.woowacourse.gongcheck.application;
 
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
+import com.woowacourse.gongcheck.presentation.Authority;
 
 public interface JwtTokenProvider {
-    String createToken(final String subject);
+    String createToken(final String subject, final Authority authority);
 
     String extractSubject(final String token) throws UnauthorizedException;
+
+    Authority extractAuthority(final String token);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubAccessTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubAccessTokenResponse.java
@@ -1,0 +1,18 @@
+package com.woowacourse.gongcheck.application.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GithubAccessTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private GithubAccessTokenResponse() {
+    }
+
+    public GithubAccessTokenResponse(final String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
@@ -1,0 +1,45 @@
+package com.woowacourse.gongcheck.application.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.woowacourse.gongcheck.domain.host.Host;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class GithubProfileResponse {
+
+    public static final String DEFAULT_SPACE_PASSWORD = "0000";
+    
+    @JsonProperty("name")
+    private String nickname;
+    @JsonProperty("login")
+    private String loginName;
+    @JsonProperty("id")
+    private String githubId;
+    @JsonProperty("avatar_url")
+    private String imageUrl;
+
+    private GithubProfileResponse() {
+    }
+
+    public GithubProfileResponse(final String nickname, final String loginName, final String githubId,
+                                 final String imageUrl) {
+        this.nickname = nickname;
+        this.loginName = loginName;
+        this.githubId = githubId;
+        this.imageUrl = imageUrl;
+    }
+
+    public Host toHost() {
+        return Host.builder()
+                .spacePassword(DEFAULT_SPACE_PASSWORD)
+                .githubId(getGithubId())
+                .imageUrl(imageUrl)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public Long getGithubId() {
+        return Long.parseLong(githubId);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
@@ -2,14 +2,11 @@ package com.woowacourse.gongcheck.application.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.gongcheck.domain.host.Host;
-import com.woowacourse.gongcheck.domain.host.SpacePassword;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
 public class GithubProfileResponse {
-
-    public static final String DEFAULT_SPACE_PASSWORD = "0000";
 
     @JsonProperty("name")
     private String nickname;
@@ -33,7 +30,6 @@ public class GithubProfileResponse {
 
     public Host toHost() {
         return Host.builder()
-                .spacePassword(new SpacePassword(DEFAULT_SPACE_PASSWORD))
                 .githubId(getGithubId())
                 .imageUrl(imageUrl)
                 .createdAt(LocalDateTime.now())

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.application.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.SpacePassword;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ import lombok.Getter;
 public class GithubProfileResponse {
 
     public static final String DEFAULT_SPACE_PASSWORD = "0000";
-    
+
     @JsonProperty("name")
     private String nickname;
     @JsonProperty("login")
@@ -32,7 +33,7 @@ public class GithubProfileResponse {
 
     public Host toHost() {
         return Host.builder()
-                .spacePassword(DEFAULT_SPACE_PASSWORD)
+                .spacePassword(new SpacePassword(DEFAULT_SPACE_PASSWORD))
                 .githubId(getGithubId())
                 .imageUrl(imageUrl)
                 .createdAt(LocalDateTime.now())

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/TokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/TokenResponse.java
@@ -1,0 +1,22 @@
+package com.woowacourse.gongcheck.application.response;
+
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+
+    private String token;
+    private boolean existHost;
+
+    private TokenResponse() {
+    }
+
+    private TokenResponse(final String token, final boolean existHost) {
+        this.token = token;
+        this.existHost = existHost;
+    }
+
+    public static TokenResponse of(final String token, final boolean existHost) {
+        return new TokenResponse(token, existHost);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/TokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/TokenResponse.java
@@ -6,17 +6,17 @@ import lombok.Getter;
 public class TokenResponse {
 
     private String token;
-    private boolean existHost;
+    private boolean alreadyJoin;
 
     private TokenResponse() {
     }
 
-    private TokenResponse(final String token, final boolean existHost) {
+    private TokenResponse(final String token, final boolean alreadyJoin) {
         this.token = token;
-        this.existHost = existHost;
+        this.alreadyJoin = alreadyJoin;
     }
 
-    public static TokenResponse of(final String token, final boolean existHost) {
-        return new TokenResponse(token, existHost);
+    public static TokenResponse of(final String token, final boolean alreadyJoin) {
+        return new TokenResponse(token, alreadyJoin);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
@@ -3,8 +3,10 @@ package com.woowacourse.gongcheck.config;
 import com.woowacourse.gongcheck.presentation.AuthenticationInterceptor;
 import com.woowacourse.gongcheck.presentation.AuthenticationPrincipalArgumentResolver;
 import java.util.List;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -35,11 +37,17 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/hosts/*/enter");
+                .excludePathPatterns("/api/hosts/*/enter")
+                .excludePathPatterns("/api/login");
     }
 
     @Override
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticationPrincipalArgumentResolver);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 public class Host {
 
     private static final int SPACE_PASSWORD_MAX_LENGTH = 4;
-    private static final String DEFAULT_SPACE_PASSWORD = "0000";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +27,7 @@ public class Host {
 
     @Embedded
     @Builder.Default
-    private SpacePassword spacePassword = new SpacePassword(DEFAULT_SPACE_PASSWORD);
+    private SpacePassword spacePassword = new SpacePassword("0000");
 
     @Column(name = "github_id", nullable = false, unique = true)
     private Long githubId;

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -18,12 +18,20 @@ import lombok.Getter;
 @Getter
 public class Host {
 
+    private static final int SPACE_PASSWORD_MAX_LENGTH = 4;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded
     private SpacePassword spacePassword;
+
+    @Column(name = "github_id", nullable = false, unique = true)
+    private Long githubId;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -35,10 +43,12 @@ public class Host {
     }
 
     @Builder
-    public Host(final Long id, final SpacePassword spacePassword, final LocalDateTime createdAt,
-                final LocalDateTime updatedAt) {
+    public Host(final Long id, final SpacePassword spacePassword, final Long githubId, final String imageUrl,
+                final LocalDateTime createdAt, final LocalDateTime updatedAt) {
         this.id = id;
         this.spacePassword = spacePassword;
+        this.githubId = githubId;
+        this.imageUrl = imageUrl;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -15,10 +15,12 @@ import lombok.Getter;
 
 @Entity
 @Table(name = "host")
+@Builder
 @Getter
 public class Host {
 
     private static final int SPACE_PASSWORD_MAX_LENGTH = 4;
+    private static final String DEFAULT_SPACE_PASSWORD = "0000";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,7 +44,6 @@ public class Host {
     protected Host() {
     }
 
-    @Builder
     public Host(final Long id, final SpacePassword spacePassword, final Long githubId, final String imageUrl,
                 final LocalDateTime createdAt, final LocalDateTime updatedAt) {
         this.id = id;

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -27,7 +27,8 @@ public class Host {
     private Long id;
 
     @Embedded
-    private SpacePassword spacePassword;
+    @Builder.Default
+    private SpacePassword spacePassword = new SpacePassword(DEFAULT_SPACE_PASSWORD);
 
     @Column(name = "github_id", nullable = false, unique = true)
     private Long githubId;

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/HostRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/HostRepository.java
@@ -1,6 +1,7 @@
 package com.woowacourse.gongcheck.domain.host;
 
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HostRepository extends JpaRepository<Host, Long> {
@@ -8,4 +9,12 @@ public interface HostRepository extends JpaRepository<Host, Long> {
     default Host getById(final Long id) throws NotFoundException {
         return findById(id).orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
     }
+
+    default Host getByGithubId(final Long githubId) throws NotFoundException {
+        return findByGithubId(githubId).orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
+    }
+
+    Optional<Host> findByGithubId(final Long githubId);
+
+    boolean existsByGithubId(final Long githubId);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/HostRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/HostRepository.java
@@ -6,6 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HostRepository extends JpaRepository<Host, Long> {
 
+    Optional<Host> findByGithubId(final Long githubId);
+
+    boolean existsByGithubId(final Long githubId);
+
     default Host getById(final Long id) throws NotFoundException {
         return findById(id).orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
     }
@@ -13,8 +17,4 @@ public interface HostRepository extends JpaRepository<Host, Long> {
     default Host getByGithubId(final Long githubId) throws NotFoundException {
         return findByGithubId(githubId).orElseThrow(() -> new NotFoundException("존재하지 않는 호스트입니다."));
     }
-
-    Optional<Host> findByGithubId(final Long githubId);
-
-    boolean existsByGithubId(final Long githubId);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationContext.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationContext.java
@@ -1,19 +1,22 @@
 package com.woowacourse.gongcheck.presentation;
 
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Component
 @RequestScope
+@Getter
 public class AuthenticationContext {
 
     private String principal;
-
-    public String getPrincipal() {
-        return principal;
-    }
+    private Authority authority;
 
     public void setPrincipal(final String principal) {
         this.principal = principal;
+    }
+
+    public void setAuthority(final Authority authority) {
+        this.authority = authority;
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/AuthenticationInterceptor.java
@@ -33,6 +33,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         String subject = jwtTokenProvider.extractSubject(token);
         authenticationContext.setPrincipal(subject);
+        Authority authority = jwtTokenProvider.extractAuthority(token);
+        authenticationContext.setAuthority(authority);
         return HandlerInterceptor.super.preHandle(request, response, handler);
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/Authority.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/Authority.java
@@ -2,8 +2,5 @@ package com.woowacourse.gongcheck.presentation;
 
 public enum Authority {
     GUEST, HOST;
-
-    Authority() {
-    }
 }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/Authority.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/Authority.java
@@ -1,0 +1,9 @@
+package com.woowacourse.gongcheck.presentation;
+
+public enum Authority {
+    GUEST, HOST;
+
+    Authority() {
+    }
+}
+

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostAuthController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostAuthController.java
@@ -1,0 +1,26 @@
+package com.woowacourse.gongcheck.presentation;
+
+import com.woowacourse.gongcheck.application.HostAuthService;
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HostAuthController {
+
+    private final HostAuthService hostAuthService;
+
+    public HostAuthController(final HostAuthService hostAuthService) {
+        this.hostAuthService = hostAuthService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody final TokenRequest tokenRequest) {
+        return ResponseEntity.ok(hostAuthService.createToken(tokenRequest));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostAuthController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostAuthController.java
@@ -20,7 +20,7 @@ public class HostAuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody final TokenRequest tokenRequest) {
-        return ResponseEntity.ok(hostAuthService.createToken(tokenRequest));
+    public ResponseEntity<TokenResponse> login(@RequestBody final TokenRequest request) {
+        return ResponseEntity.ok(hostAuthService.createToken(request));
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/GithubAccessTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/GithubAccessTokenRequest.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 public class GithubAccessTokenRequest {
 
     private String code;
+
     @JsonProperty("client_id")
     private String clientId;
+
     @JsonProperty("client_secret")
     private String clientSecret;
 
@@ -19,17 +21,5 @@ public class GithubAccessTokenRequest {
         this.code = code;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/GithubAccessTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/GithubAccessTokenRequest.java
@@ -1,0 +1,35 @@
+package com.woowacourse.gongcheck.presentation.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class GithubAccessTokenRequest {
+
+    private String code;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("client_secret")
+    private String clientSecret;
+
+    private GithubAccessTokenRequest() {
+    }
+
+    public GithubAccessTokenRequest(final String code, final String clientId, final String clientSecret) {
+        this.code = code;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/TokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/TokenRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.gongcheck.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRequest {
+
+    private String code;
+
+    private TokenRequest() {
+    }
+
+    public TokenRequest(final String code) {
+        this.code = code;
+    }
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,7 @@
+github:
+  client:
+    id: client_id
+    secret: client_secret
+  url:
+    token: https://github.com/login/oauth/access_token
+    profile: https://api.github.com/user

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
     init:
       schema-locations: classpath:schema.sql
       data-locations: classpath:dummy_data.sql
+  profiles:
+    include: oauth
 security:
   jwt:
     token:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
       schema-locations: classpath:schema.sql
       data-locations: classpath:dummy_data.sql
   profiles:
-    include: oauth
+    include: test
 security:
   jwt:
     token:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
       schema-locations: classpath:schema.sql
       data-locations: classpath:dummy_data.sql
   profiles:
-    include: test
+    include: oauth
 security:
   jwt:
     token:

--- a/backend/src/main/resources/dummy_data.sql
+++ b/backend/src/main/resources/dummy_data.sql
@@ -1,5 +1,5 @@
-INSERT INTO host (space_password, created_at)
-VALUES ('1234', current_timestamp());
+INSERT INTO host (space_password, github_id, image_url, created_at)
+VALUES ('1234', 1, 'test.com', current_timestamp());
 
 INSERT INTO space (host_id, name, img_url, created_at)
 VALUES (1, '잠실', 'https://velog.velcdn.com/images/cks3066/post/258f92c1-32be-4acb-be30-1eb64635c013/image.jpg',

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -2,6 +2,8 @@ CREATE TABLE host
 (
     id             BIGINT     NOT NULL AUTO_INCREMENT,
     space_password VARCHAR(4) NOT NULL,
+    github_id      BIGINT     NOT NULL UNIQUE,
+    image_url      VARCHAR    NOT NULL,
     created_at     TIMESTAMP  NOT NULL,
     updated_at     TIMESTAMP NULL,
     PRIMARY KEY (id)

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AuthSupport.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AuthSupport.java
@@ -1,7 +1,9 @@
 package com.woowacourse.gongcheck.acceptance;
 
 import com.woowacourse.gongcheck.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.application.response.TokenResponse;
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
 import io.restassured.RestAssured;
 import org.springframework.http.MediaType;
 
@@ -17,5 +19,16 @@ public class AuthSupport {
                 .extract()
                 .as(GuestTokenResponse.class)
                 .getToken();
+    }
+
+    public static TokenResponse Host_토큰을_요청한다(final TokenRequest tokenRequest) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(tokenRequest)
+                .when().post("/fake/login")
+                .then().log().all()
+                .extract()
+                .as(TokenResponse.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/FakeHostAuthController.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/FakeHostAuthController.java
@@ -1,0 +1,56 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.gongcheck.application.HostAuthService;
+import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
+import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+public class FakeHostAuthController {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private HostAuthService hostAuthService;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @PostMapping("/fake/login")
+    public ResponseEntity<TokenResponse> login() throws JsonProcessingException {
+        MockRestServiceServer mockRestServiceServer = MockRestServiceServer.createServer(restTemplate);
+        mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(new GithubAccessTokenResponse("token"))));
+
+        GithubProfileResponse githubProfileResponse = new GithubProfileResponse("nickname", "loginName",
+                "1234", "test.com");
+        mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(githubProfileResponse)));
+
+        TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAuthAcceptanceTest.java
@@ -1,0 +1,57 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.Host_토큰을_요청한다;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class HostAuthAcceptanceTest extends AcceptanceTest {
+    @Test
+    void 첫_로그인한_Host이면_회원가입하고_토큰을_발급한다() {
+        TokenRequest tokenRequest = new TokenRequest("code");
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(tokenRequest)
+                .when().post("/fake/login")
+                .then().log().all()
+                .extract();
+
+        TokenResponse tokenResponse = response.jsonPath().getObject(".", TokenResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(tokenResponse.getToken()).isNotNull(),
+                () -> assertThat(tokenResponse.isAlreadyJoin()).isFalse()
+        );
+    }
+
+    @Test
+    void 첫_로그인한_Host가_아니면_토큰을_발급한다() {
+        TokenRequest tokenRequest = new TokenRequest("code");
+
+        Host_토큰을_요청한다(tokenRequest);
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(tokenRequest)
+                .when().post("/fake/login")
+                .then().log().all()
+                .extract();
+
+        TokenResponse tokenResponse = response.jsonPath().getObject(".", TokenResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(tokenResponse.getToken()).isNotNull(),
+                () -> assertThat(tokenResponse.isAlreadyJoin()).isTrue()
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
@@ -1,0 +1,91 @@
+package com.woowacourse.gongcheck.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
+import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootTest
+@Transactional
+class GithubOauthClientTest {
+
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private GithubOauthClient githubOauthClient;
+
+    @BeforeEach
+    void setUp() {
+        mockRestServiceServer = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    @Test
+    void code를_받아_access_token을_반환한다() throws JsonProcessingException {
+        GithubAccessTokenResponse token = new GithubAccessTokenResponse("access_token");
+        mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(token)));
+
+        String result = githubOauthClient.requestAccessToken("code");
+        mockRestServiceServer.verify();
+
+        assertThat(token.getAccessToken()).isEqualTo(result);
+    }
+
+    @Test
+    void 올바르지_않은_code이면_예외가_발생한다() throws JsonProcessingException {
+        GithubAccessTokenResponse token = new GithubAccessTokenResponse(null);
+        mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(token)));
+
+        assertThatThrownBy(() -> githubOauthClient.requestAccessToken("code"))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("잘못된 요청입니다.");
+        mockRestServiceServer.verify();
+    }
+
+    @Test
+    void 깃허브_프로필을_요청한다() throws JsonProcessingException {
+        GithubProfileResponse githubProfileResponse = new GithubProfileResponse("nickname", "loginName", "1",
+                "test.com");
+        mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(githubProfileResponse)));
+
+        GithubProfileResponse result = githubOauthClient.requestGithubProfile("access_token");
+        mockRestServiceServer.verify();
+
+        assertThat(githubProfileResponse).usingRecursiveComparison()
+                .isEqualTo(result);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
@@ -59,6 +59,19 @@ class GithubOauthClientTest {
     }
 
     @Test
+    void 깃허브_access_Token_요청에_실패하면_예외가_발생한다() {
+        mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND)
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> githubOauthClient.requestAccessToken("code"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("해당 사용자의 프로필을 요청할 수 없습니다.");
+        mockRestServiceServer.verify();
+    }
+
+    @Test
     void 올바르지_않은_code이면_예외가_발생한다() throws JsonProcessingException {
         GithubAccessTokenResponse token = new GithubAccessTokenResponse(null);
         mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
@@ -73,12 +73,11 @@ class GithubOauthClientTest {
 
     @Test
     void 올바르지_않은_code이면_예외가_발생한다() throws JsonProcessingException {
-        GithubAccessTokenResponse token = new GithubAccessTokenResponse(null);
         mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(objectMapper.writeValueAsString(token)));
+                        .body(objectMapper.writeValueAsString(null)));
 
         assertThatThrownBy(() -> githubOauthClient.requestAccessToken("code"))
                 .isInstanceOf(UnauthorizedException.class)

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/GithubOauthClientTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.gongcheck.application.response.GithubAccessTokenResponse;
 import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.exception.NotFoundException;
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,5 +88,19 @@ class GithubOauthClientTest {
 
         assertThat(githubProfileResponse).usingRecursiveComparison()
                 .isEqualTo(result);
+    }
+
+    @Test
+    void 깃허브_프로필_요청에_실패하면_예외가_발생한다() throws JsonProcessingException {
+        mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.NOT_FOUND)
+                        .contentType(MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> githubOauthClient
+                .requestGithubProfile("access_token"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("해당 사용자의 프로필을 요청할 수 없습니다.");
+        mockRestServiceServer.verify();
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/GuestAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/GuestAuthServiceTest.java
@@ -38,7 +38,7 @@ class GuestAuthServiceTest {
 
         @Test
         void 비밀번호가_틀리면_예외가_발생한다() {
-            Host host = hostRepository.save(Host_생성("0123"));
+            Host host = hostRepository.save(Host_생성("0123", 1234L));
 
             assertThatThrownBy(() -> guestAuthService.createToken(host.getId(), new GuestEnterRequest("1234")))
                     .isInstanceOf(UnauthorizedException.class)
@@ -47,7 +47,7 @@ class GuestAuthServiceTest {
 
         @Test
         void 정상적으로_토큰을_발행한다() {
-            Host host = hostRepository.save(Host_생성("0123"));
+            Host host = hostRepository.save(Host_생성("0123", 1234L));
             GuestTokenResponse token = guestAuthService.createToken(host.getId(), new GuestEnterRequest("0123"));
 
             assertThat(token.getToken()).isNotNull();

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/HostAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/HostAuthServiceTest.java
@@ -1,0 +1,62 @@
+package com.woowacourse.gongcheck.application;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class HostAuthServiceTest {
+
+    @Autowired
+    private HostAuthService hostAuthService;
+
+    @MockBean
+    private GithubOauthClient githubOauthClient;
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    void code를_받아_token과_존재하지_않는_Host이면_false를_반환한다() {
+        GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
+                "test.com");
+        when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
+        when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
+
+        TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+
+        assertThat(result)
+                .extracting("token", "existHost")
+                .containsExactly("jwt.token.here", false);
+    }
+
+    @Test
+    void code를_받아_token과_이미_존재하는_Host이면_true를_반환한다() {
+        hostRepository.save(Host_생성("1234", 1234L));
+        GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
+                "test.com");
+        when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
+        when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
+
+        TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+
+        assertThat(result)
+                .extracting("token", "existHost")
+                .containsExactly("jwt.token.here", true);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/HostAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/HostAuthServiceTest.java
@@ -9,6 +9,7 @@ import com.woowacourse.gongcheck.application.response.GithubProfileResponse;
 import com.woowacourse.gongcheck.application.response.TokenResponse;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,32 +32,36 @@ class HostAuthServiceTest {
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
-    @Test
-    void code를_받아_token과_존재하지_않는_Host이면_false를_반환한다() {
-        GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
-                "test.com");
-        when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
-        when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
+    @Nested
+    class code를_받아_token을_반환한다 {
 
-        TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+        @Test
+        void 존재하지_않는_Host이면_alreadyJoin이_false이다() {
+            GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
+                    "test.com");
+            when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
+            when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
 
-        assertThat(result)
-                .extracting("token", "existHost")
-                .containsExactly("jwt.token.here", false);
-    }
+            TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
 
-    @Test
-    void code를_받아_token과_이미_존재하는_Host이면_true를_반환한다() {
-        hostRepository.save(Host_생성("1234", 1234L));
-        GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
-                "test.com");
-        when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
-        when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
+            assertThat(result)
+                    .extracting("token", "alreadyJoin")
+                    .containsExactly("jwt.token.here", false);
+        }
 
-        TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+        @Test
+        void 이미_존재하는_Host이면_alreadyJoin이_true이다() {
+            hostRepository.save(Host_생성("1234", 1234L));
+            GithubProfileResponse response = new GithubProfileResponse("nickname", "loginName", "1234",
+                    "test.com");
+            when(githubOauthClient.requestGithubProfile(any())).thenReturn(response);
+            when(jwtTokenProvider.createToken(any(), any())).thenReturn("jwt.token.here");
 
-        assertThat(result)
-                .extracting("token", "existHost")
-                .containsExactly("jwt.token.here", true);
+            TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
+
+            assertThat(result)
+                    .extracting("token", "alreadyJoin")
+                    .containsExactly("jwt.token.here", true);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
@@ -1,12 +1,11 @@
 package com.woowacourse.gongcheck.application;
 
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.*;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.host.SpacePassword;
 import com.woowacourse.gongcheck.exception.NotFoundException;
-import com.woowacourse.gongcheck.fixture.FixtureFactory;
 import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,7 +25,7 @@ class HostServiceTest {
 
     @Test
     void SpacePassword를_변경한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         String changedPassword = "4567";
         hostService.changeSpacePassword(host.getId(), new SpacePasswordChangeRequest(changedPassword));

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/JjwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/JjwtTokenProviderTest.java
@@ -67,4 +67,13 @@ class JjwtTokenProviderTest {
 
         assertThat(tokenProvider.extractAuthority(token)).isEqualTo(GUEST);
     }
+
+    @Test
+    void 권한_반환에_실패하면_예외가_발생한다() {
+        String invalidToken = "invalidToken";
+
+        assertThatThrownBy(() -> tokenProvider.extractAuthority(invalidToken))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("올바르지 않은 토큰입니다.");
+    }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/JjwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/JjwtTokenProviderTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.gongcheck.application;
 
+import static com.woowacourse.gongcheck.presentation.Authority.GUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -18,7 +19,7 @@ class JjwtTokenProviderTest {
 
     @Test
     void 토큰을_생성한다() {
-        String token = tokenProvider.createToken("1");
+        String token = tokenProvider.createToken("1", GUEST);
 
         assertThat(token).isNotNull();
     }
@@ -54,5 +55,16 @@ class JjwtTokenProviderTest {
                 .compact();
 
         assertThat(tokenProvider.extractSubject(token)).isEqualTo(subject);
+    }
+
+    @Test
+    void 권한을_반환한다() {
+        String token = Jwts.builder()
+                .setSubject("1")
+                .claim("authority", GUEST)
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(key)), SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThat(tokenProvider.extractAuthority(token)).isEqualTo(GUEST);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/JobServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/JobServiceTest.java
@@ -43,7 +43,7 @@ class JobServiceTest {
 
     @Test
     void Job_목록을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job1 = Job_생성(space, "오픈");
         Job job2 = Job_생성(space, "청소");
@@ -67,7 +67,7 @@ class JobServiceTest {
 
     @Test
     void 존재하지_않는_Space의_Job_목록을_조회할_경우_예외를_던진다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         assertThatThrownBy(() -> jobService.findPage(host.getId(), 0L, PageRequest.of(0, 1)))
                 .isInstanceOf(NotFoundException.class)
@@ -76,8 +76,8 @@ class JobServiceTest {
 
     @Test
     void 다른_Host의_Space의_Job_목록을_조회할_경우_예외를_던진다() {
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
+        Host host1 = hostRepository.save(Host_생성("1234", 1234L));
+        Host host2 = hostRepository.save(Host_생성("1234", 2345L));
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
 
         assertThatThrownBy(() -> jobService.findPage(host1.getId(), space.getId(), PageRequest.of(0, 1)))
@@ -87,7 +87,7 @@ class JobServiceTest {
 
     @Test
     void Job과_Section들과_Task들을_한_번에_생성한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         List<TaskCreateRequest> tasks = List.of(new TaskCreateRequest("책상 닦기"), new TaskCreateRequest("칠판 닦기"));
         List<SectionCreateRequest> sections = List.of(new SectionCreateRequest("대강의실", tasks));
@@ -100,7 +100,7 @@ class JobServiceTest {
 
     @Test
     void Host가_존재하지_않는데_Job_생성_시_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
 
         List<TaskCreateRequest> tasks = List.of(new TaskCreateRequest("책상 닦기"), new TaskCreateRequest("칠판 닦기"));
@@ -114,7 +114,7 @@ class JobServiceTest {
 
     @Test
     void Space가_존재하지_않는데_Job_생성_시_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         List<TaskCreateRequest> tasks = List.of(new TaskCreateRequest("책상 닦기"), new TaskCreateRequest("칠판 닦기"));
         List<SectionCreateRequest> sections = List.of(new SectionCreateRequest("대강의실", tasks));

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
@@ -69,7 +69,7 @@ class SpaceServiceTest {
 
         @Test
         void 공간을_조회한다() {
-            Host host = hostRepository.save(Host_생성("1234"));
+            Host host = hostRepository.save(Host_생성("1234", 1234L));
             Space space1 = Space_생성(host, "잠실");
             Space space2 = Space_생성(host, "선릉");
             Space space3 = Space_생성(host, "양평같은방");
@@ -96,7 +96,7 @@ class SpaceServiceTest {
 
         @Test
         void 공간을_생성한다() {
-            Host host = hostRepository.save(Host_생성("1234"));
+            Host host = hostRepository.save(Host_생성("1234", 1234L));
             SpaceCreateRequest spaceCreateRequest = new SpaceCreateRequest("잠실 캠퍼스",
                     new MockMultipartFile("잠실 캠퍼스 사진", new byte[]{}));
             Long spaceId = spaceService.createSpace(host.getId(), spaceCreateRequest);
@@ -106,7 +106,7 @@ class SpaceServiceTest {
 
         @Test
         void 이미_존재하는_공간_이름을_입력할_경우_예외가_발생한다() {
-            Host host = hostRepository.save(Host_생성("1234"));
+            Host host = hostRepository.save(Host_생성("1234", 1234L));
             String spaceName = "잠실 캠퍼스";
             Space space = Space_생성(host, spaceName);
             spaceRepository.save(space);
@@ -132,7 +132,7 @@ class SpaceServiceTest {
 
     @Test
     void Space를_삭제하면_관련된_Job_Section_Task_RunningTask를_함께_삭제한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "대강의실"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SubmissionServiceTest.java
@@ -78,8 +78,8 @@ class SubmissionServiceTest {
 
         @BeforeEach
         void setUp() {
-            hostWithoutTasks = hostRepository.save(Host_생성("1234"));
-            hostWithTasks = hostRepository.save(Host_생성("1234"));
+            hostWithoutTasks = hostRepository.save(Host_생성("1234", 1234L));
+            hostWithTasks = hostRepository.save(Host_생성("1234", 2345L));
             space = spaceRepository.save(Space_생성(hostWithTasks, "잠실"));
             job = jobRepository.save(Job_생성(space, "청소"));
             section = sectionRepository.save(Section_생성(job, "트랙룸"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/TaskServiceTest.java
@@ -75,7 +75,7 @@ class TaskServiceTest {
 
     @Test
     void 존재하지_않는_작업의_새로운_작업을_진행하려는_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         assertThatThrownBy(() -> taskService.createNewRunningTasks(host.getId(), 0L))
                 .isInstanceOf(NotFoundException.class)
@@ -84,8 +84,8 @@ class TaskServiceTest {
 
     @Test
     void 다른_호스트의_작업의_새로운_작업을_진행하려는_경우_예외가_발생한다() {
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
+        Host host1 = hostRepository.save(Host_생성("1234", 1234L));
+        Host host2 = hostRepository.save(Host_생성("1234", 2345L));
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
 
@@ -96,7 +96,7 @@ class TaskServiceTest {
 
     @Test
     void 이미_진행중인_작업이_존재하는데_새로운_작업을_진행하려는_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -114,7 +114,7 @@ class TaskServiceTest {
 
     @Test
     void 정상적으로_새로운_진행_작업을_생성한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -139,7 +139,7 @@ class TaskServiceTest {
 
         @BeforeEach
         void setUp() {
-            host = hostRepository.save(Host_생성("1234"));
+            host = hostRepository.save(Host_생성("1234", 1234L));
             space = spaceRepository.save(Space_생성(host, "잠실"));
             job = jobRepository.save(Job_생성(space, "청소"));
             section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -155,7 +155,7 @@ class TaskServiceTest {
 
         @Test
         void 존재하지_않는_작업으로_확인하려는_경우_예외가_발생한다() {
-            Host host = hostRepository.save(Host_생성("1234"));
+            Host host = hostRepository.save(Host_생성("1234", 2345L));
 
             assertThatThrownBy(() -> taskService.isJobActivated(host.getId(), 0L))
                     .isInstanceOf(NotFoundException.class)
@@ -164,12 +164,11 @@ class TaskServiceTest {
 
         @Test
         void 다른_호스트의_작업으로_확인하려는_경우_예외가_발생한다() {
-            Host host1 = hostRepository.save(Host_생성("1234"));
-            Host host2 = hostRepository.save(Host_생성("1234"));
-            Space space = spaceRepository.save(Space_생성(host2, "잠실"));
+            Host host1 = hostRepository.save(Host_생성("1234", 2345L));
+            Space space = spaceRepository.save(Space_생성(host1, "잠실"));
             Job job = jobRepository.save(Job_생성(space, "청소"));
 
-            assertThatThrownBy(() -> taskService.isJobActivated(host1.getId(), job.getId()))
+            assertThatThrownBy(() -> taskService.isJobActivated(host.getId(), job.getId()))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage("존재하지 않는 작업입니다.");
         }
@@ -202,7 +201,7 @@ class TaskServiceTest {
 
         @BeforeEach
         void init() {
-            host = hostRepository.save(Host_생성("1234"));
+            host = hostRepository.save(Host_생성("1234", 1234L));
             space = spaceRepository.save(Space_생성(host, "잠실"));
             job = jobRepository.save(Job_생성(space, "청소"));
             section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -219,7 +218,7 @@ class TaskServiceTest {
 
         @Test
         void 존재하지_않는_작업의_진행중인_작업을_조회하려는_경우_예외가_발생한다() {
-            Host host = hostRepository.save(Host_생성("1234"));
+            Host host = hostRepository.save(Host_생성("1234", 2345L));
 
             assertThatThrownBy(() -> taskService.findRunningTasks(host.getId(), 0L))
                     .isInstanceOf(NotFoundException.class)
@@ -228,7 +227,7 @@ class TaskServiceTest {
 
         @Test
         void 다른_호스트의_작업의_진행중인_작업을_조회하려는_경우_예외가_발생한다() {
-            Host differentHost = hostRepository.save(Host_생성("1234"));
+            Host differentHost = hostRepository.save(Host_생성("1234", 2345L));
             taskRepository.saveAll(List.of(task1, task2));
             RunningTask runningTask1 = RunningTask_생성(task1.getId(), false);
             RunningTask runningTask2 = RunningTask_생성(task2.getId(), false);
@@ -266,7 +265,7 @@ class TaskServiceTest {
 
     @Test
     void 진행_작업_체크_시_진행_작업이_존재하지_않을_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -280,13 +279,13 @@ class TaskServiceTest {
 
     @Test
     void 진행_작업_체크_시_입력한_host의_진행_작업이_아닐_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
         Task task = Task_생성(section, "책상 청소");
 
-        Host differentHost = hostRepository.save(Host_생성("1234"));
+        Host differentHost = hostRepository.save(Host_생성("1234", 2345L));
         Space differentSpace = spaceRepository.save(Space_생성(differentHost, "선릉"));
         Job differentJob = jobRepository.save(Job_생성(differentSpace, "청소"));
         Section differentSection = sectionRepository.save(Section_생성(differentJob, "트랙룸"));
@@ -304,7 +303,7 @@ class TaskServiceTest {
 
     @Test
     void 진행_작업_체크_시_Host가_존재하지_않는_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -320,7 +319,7 @@ class TaskServiceTest {
     @ParameterizedTest
     @CsvSource(value = {"false:true", "true:false"}, delimiter = ':')
     void 진행_작업의_상태를_변경한다(final boolean input, final boolean expected) {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section = sectionRepository.save(Section_생성(job, "트랙룸"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 
 import com.woowacourse.gongcheck.application.AlertService;
 import com.woowacourse.gongcheck.application.GuestAuthService;
+import com.woowacourse.gongcheck.application.HostAuthService;
 import com.woowacourse.gongcheck.application.HostService;
 import com.woowacourse.gongcheck.application.ImageUploader;
 import com.woowacourse.gongcheck.application.JjwtTokenProvider;
@@ -45,6 +46,9 @@ class DocumentationTest {
 
     protected MockMvcRequestSpecification docsGiven;
 
+    @MockBean
+    protected HostAuthService hostAuthService;
+    
     @MockBean
     protected GuestAuthService guestAuthService;
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -14,6 +14,7 @@ import com.woowacourse.gongcheck.application.SubmissionService;
 import com.woowacourse.gongcheck.application.TaskService;
 import com.woowacourse.gongcheck.presentation.AuthenticationContext;
 import com.woowacourse.gongcheck.presentation.GuestAuthController;
+import com.woowacourse.gongcheck.presentation.HostAuthController;
 import com.woowacourse.gongcheck.presentation.HostController;
 import com.woowacourse.gongcheck.presentation.JobController;
 import com.woowacourse.gongcheck.presentation.SpaceController;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @WebMvcTest({
+        HostAuthController.class,
         GuestAuthController.class,
         SpaceController.class,
         JobController.class,

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
@@ -1,0 +1,34 @@
+package com.woowacourse.gongcheck.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.woowacourse.gongcheck.application.response.TokenResponse;
+import com.woowacourse.gongcheck.presentation.request.TokenRequest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class HostAuthDocumentation extends DocumentationTest {
+
+    @Nested
+    class 호스트_토큰을_요청한다 {
+
+        @Test
+        void 로그인에_성공하면_호스트_토큰을_반환한다() {
+            TokenRequest tokenRequest = new TokenRequest("authorization-code");
+            TokenResponse tokenResponse = TokenResponse.of("jwt.token.here", true);
+            when(hostAuthService.createToken(any())).thenReturn(tokenResponse);
+
+            docsGiven
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(tokenRequest)
+                    .when().post("api/login")
+                    .then().log().all()
+                    .apply(document("hosts/auth/success"))
+                    .statusCode(HttpStatus.OK.value());
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -30,12 +30,12 @@ class JobDocumentation extends DocumentationTest {
 
         @Test
         void Job_조회에_성공한다() {
-            Host host = Host_생성("1234");
+            Host host = Host_생성("1234", 1234L);
             Space space = Space_생성(host, "잠실");
             when(jobService.findPage(anyLong(), anyLong(), any())).thenReturn(
                     JobsResponse.of(List.of(
-                            Job_아이디_지정_생성(1L, space, "청소"),
-                            Job_아이디_지정_생성(2L, space, "마감")),
+                                    Job_아이디_지정_생성(1L, space, "청소"),
+                                    Job_아이디_지정_생성(2L, space, "마감")),
                             true)
             );
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
@@ -55,7 +55,8 @@ class JobDocumentation extends DocumentationTest {
     class Job을_생성_시 {
         List<TaskCreateRequest> tasks1 = List.of(new TaskCreateRequest("책상 닦기"), new TaskCreateRequest("칠판 닦기"));
         List<TaskCreateRequest> tasks2 = List.of(new TaskCreateRequest("책상 닦기"), new TaskCreateRequest("칠판 닦기"));
-        List<SectionCreateRequest> sections = List.of(new SectionCreateRequest("대강의실", tasks1), new SectionCreateRequest("소강의실", tasks2));
+        List<SectionCreateRequest> sections = List.of(new SectionCreateRequest("대강의실", tasks1),
+                new SectionCreateRequest("소강의실", tasks2));
 
         @Test
         void Job을_생성한다() {
@@ -110,7 +111,8 @@ class JobDocumentation extends DocumentationTest {
         @Test
         void Task_이름_길이가_올바르지_않을_경우_예외가_발생한다() {
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
-            List<TaskCreateRequest> tasks1 = List.of(new TaskCreateRequest("Task의 이름이 1글자 미만 50글자 초과일 경우, Status Code 404를 반환한다"));
+            List<TaskCreateRequest> tasks1 = List.of(
+                    new TaskCreateRequest("Task의 이름이 1글자 미만 50글자 초과일 경우, Status Code 404를 반환한다"));
             List<SectionCreateRequest> sections = List.of(new SectionCreateRequest("대강의실", tasks1));
             JobCreateRequest wrongRequest = new JobCreateRequest("청소", sections);
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -26,7 +26,7 @@ class SpaceDocumentation extends DocumentationTest {
 
         @Test
         void 공간_조회에_성공한다() {
-            Host host = Host_생성("1234");
+            Host host = Host_생성("1234", 1234L);
             when(spaceService.findPage(anyLong(), any())).thenReturn(
                     SpacesResponse.of(List.of(
                             Space_아이디_지정_생성(1L, host, "잠실"),

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
@@ -34,7 +34,7 @@ class SubmissionDocumentation extends DocumentationTest {
 
         @Test
         void 현재_진행중인_작업이_모두_완료된_상태로_제출하면_제출에_성공한다() {
-            Host host = Host_생성("1234");
+            Host host = Host_생성("1234", 1234L);
             Space space = Space_아이디_지정_생성(1L, host, "잠실");
             Job job = Job_아이디_지정_생성(1L, space, "청소");
             SubmissionResponse response = SubmissionResponse.of("author", job);

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/TaskDocumentation.java
@@ -92,7 +92,7 @@ class TaskDocumentation extends DocumentationTest {
 
         @Test
         void 진행중인_작업이_있으면_조회에_성공한다() {
-            Host host = Host_생성("1234");
+            Host host = Host_생성("1234", 1234L);
             Space space = Space_생성(host, "잠실");
             Job job = Job_생성(space, "청소");
             Section section1 = Section_아이디_지정_생성(1L, job, "트랙룸");

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostRepositoryTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -17,7 +19,7 @@ class HostRepositoryTest {
 
     @Test
     void 아이디로_호스트를_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         Host result = hostRepository.getById(host.getId());
 
@@ -29,5 +31,33 @@ class HostRepositoryTest {
         assertThatThrownBy(() -> hostRepository.getById(0L))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 호스트입니다.");
+    }
+
+    @Test
+    void 깃허브_아이디로_호스트를_조회한다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+
+        Host result = hostRepository.getByGithubId(1234L);
+
+        assertThat(result).isEqualTo(host);
+    }
+
+    @Test
+    void 깃허브_아이디로_조회시_해당하는_호스트가_없으면_예외가_발생한다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+
+        assertThatThrownBy(() -> hostRepository.getByGithubId(1235L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 호스트입니다.");
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"1234, true", "1235, false"})
+    void 깃허브_아이디로_호스트가_존재하는지_확인한다(final Long githubId, final boolean actual) {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+
+        boolean result = hostRepository.existsByGithubId(githubId);
+
+        assertThat(result).isEqualTo(actual);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
@@ -16,7 +16,7 @@ class HostTest {
         Host host = Host.builder()
                 .build();
 
-        assertThat(host.getSpacePassword()).isEqualTo("0000");
+        assertThat(host.getSpacePassword().getValue()).isEqualTo("0000");
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
@@ -14,7 +14,7 @@ class HostTest {
     @Nested
     class 비밀번호를_검사할_때 {
 
-        private final Host host = Host_생성("0123");
+        private final Host host = Host_생성("0123", 1234L);
 
         @Test
         void 일치하지_않으면_예외가_발생한다() {
@@ -34,7 +34,7 @@ class HostTest {
 
     @Test
     void SpacePassword를_수정한다() {
-        Host host = Host_생성("0123");
+        Host host = Host_생성("0123", 1234L);
         String changedPassword = "4567";
 
         host.changeSpacePassword(new SpacePassword(changedPassword));

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
@@ -11,6 +11,14 @@ import org.junit.jupiter.api.Test;
 
 class HostTest {
 
+    @Test
+    void Host_생성시_기본_비밀번호는_0000_이다() {
+        Host host = Host.builder()
+                .build();
+
+        assertThat(host.getSpacePassword()).isEqualTo("0000");
+    }
+
     @Nested
     class 비밀번호를_검사할_때 {
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
@@ -33,7 +33,7 @@ class JobRepositoryTest {
 
     @Test
     void 멤버와_Space으로_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job1 = Job_생성(space, "오픈");
         Job job2 = Job_생성(space, "청소");
@@ -50,7 +50,7 @@ class JobRepositoryTest {
 
     @Test
     void 멤버와_아이디로_작업을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
 
@@ -61,8 +61,8 @@ class JobRepositoryTest {
 
     @Test
     void 다른_Host의_Job을_조회할_경우_예외가_발생한다() {
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
+        Host host1 = hostRepository.save(Host_생성("1234", 1234L));
+        Host host2 = hostRepository.save(Host_생성("1234", 2345L));
         Space space = spaceRepository.save(Space_생성(host2, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
 
@@ -73,7 +73,7 @@ class JobRepositoryTest {
 
     @Test
     void 입력된_Space에_등록된_모든_Job을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
         Job job1 = jobRepository.save(Job_생성(space, "청소"));
         Job job2 = jobRepository.save(Job_생성(space, "마감"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
@@ -34,7 +34,7 @@ class SectionRepositoryTest {
 
     @Test
     void 입력된_Job_목록에_해당하는_모든_Section을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job1 = jobRepository.save(Job_생성(space, "청소"));
         Job job2 = jobRepository.save(Job_생성(space, "마감"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
@@ -27,7 +27,7 @@ class SpaceRepositoryTest {
 
     @Test
     void 멤버아이디로_공간을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space1 = Space_생성(host, "잠실");
         Space space2 = Space_생성(host, "선릉");
         Space space3 = Space_생성(host, "양평같은방");
@@ -43,7 +43,7 @@ class SpaceRepositoryTest {
 
     @Test
     void 멤버와_아이디로_공간을_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
 
         Space result = spaceRepository.getByHostAndId(host, space.getId());
@@ -53,8 +53,8 @@ class SpaceRepositoryTest {
 
     @Test
     void 다른_호스트의_공간을_조회할_경우_예외가_발생한다() {
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
+        Host host1 = hostRepository.save(Host_생성("1234", 1234L));
+        Host host2 = hostRepository.save(Host_생성("1234", 2345L));
         Space space = Space_생성(host2, "잠실");
         spaceRepository.save(space);
 
@@ -66,7 +66,7 @@ class SpaceRepositoryTest {
 
     @Test
     void 호스트와_공간_이름을_입력_받아_이미_존재하는_공간_이름이면_참을_반환한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = Space_생성(host, "잠실");
         spaceRepository.save(space);
 
@@ -77,7 +77,7 @@ class SpaceRepositoryTest {
 
     @Test
     void 호스트와_공간_이름을_입력_받아_이미_존재하는_공간_이름이_아니면_거짓을_반환한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         boolean result = spaceRepository.existsByHostAndName(host, "잠실");
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceTest.java
@@ -11,7 +11,7 @@ class SpaceTest {
 
     @Test
     void Space_이름은_20자_이하여야_한다() {
-        Host host = Host_생성("1234");
+        Host host = Host_생성("1234", 1234L);
 
         assertThatThrownBy(
                 () -> Space.builder()
@@ -25,7 +25,7 @@ class SpaceTest {
 
     @Test
     void Space_이름은_빈_값일_수_없다() {
-        Host host = Host_생성("1234");
+        Host host = Host_생성("1234", 1234L);
 
         assertThatThrownBy(
                 () -> Space.builder()

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
@@ -56,7 +56,7 @@ class RunningTaskRepositoryTest {
 
         @BeforeEach
         void setUp() {
-            host = hostRepository.save(Host_생성("1234"));
+            host = hostRepository.save(Host_생성("1234", 1234L));
             space = spaceRepository.save(Space_생성(host, "잠실"));
             job = jobRepository.save(Job_생성(space, "청소"));
             section = sectionRepository.save(Section_생성(job, "트랙룸"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
@@ -42,7 +42,7 @@ class TaskRepositoryTest {
 
     @Test
     void Job이_가진_모든_Task를_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -57,7 +57,7 @@ class TaskRepositoryTest {
 
     @Test
     void Host와_TaskId를_입력_받아_Task를_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -70,7 +70,7 @@ class TaskRepositoryTest {
 
     @Test
     void 입력받은_TaskId에_해당하는_Task가_없는_경우_예외가_발생한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
 
         assertThatThrownBy(() -> taskRepository.getBySectionJobSpaceHostAndId(host, 0L))
                 .isInstanceOf(NotFoundException.class)
@@ -79,8 +79,8 @@ class TaskRepositoryTest {
 
     @Test
     void 입력받은_Host에_해당하는_Task가_없는_경우_예외가_발생한다() {
-        Host host1 = hostRepository.save(Host_생성("1234"));
-        Host host2 = hostRepository.save(Host_생성("1234"));
+        Host host1 = hostRepository.save(Host_생성("1234", 1234L));
+        Host host2 = hostRepository.save(Host_생성("1234", 2345L));
         Space space = spaceRepository.save(Space_생성(host1, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));
@@ -93,7 +93,7 @@ class TaskRepositoryTest {
 
     @Test
     void 입력받은_Section_목록에_해당하는_모든_Task를_조회한다() {
-        Host host = hostRepository.save(Host_생성("1234"));
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
         Space space = spaceRepository.save(Space_생성(host, "잠실"));
         Job job = jobRepository.save(Job_생성(space, "청소"));
         Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -11,9 +11,11 @@ import java.time.LocalDateTime;
 
 public class FixtureFactory {
 
-    public static Host Host_생성(final String password) {
+    public static Host Host_생성(final String password, final Long githubId) {
         return Host.builder()
                 .spacePassword(new SpacePassword(password))
+                .githubId(githubId)
+                .imageUrl("test.com")
                 .createdAt(LocalDateTime.now()).build();
     }
 
@@ -76,7 +78,8 @@ public class FixtureFactory {
                 .build();
     }
 
-    public static Task RunningTask로_Task_아이디_지정_생성(final Long id, final RunningTask runningTask, final Section section, final String name) {
+    public static Task RunningTask로_Task_아이디_지정_생성(final Long id, final RunningTask runningTask, final Section section,
+                                                   final String name) {
         return Task.builder()
                 .id(id)
                 .section(section)

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -19,7 +19,7 @@ spring:
         format_sql: true
     open-in-view: false
   profiles:
-    include: oauth
+    include: test
 security:
   jwt:
     token:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,7 +18,8 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
-
+  profiles:
+    include: oauth
 security:
   jwt:
     token:

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -1,9 +1,18 @@
-INSERT INTO host (space_password, created_at) VALUES ('1234', current_timestamp());
-INSERT INTO space (host_id, name, created_at) VALUES (1, '잠실', current_timestamp());
-INSERT INTO job (space_id, name, created_at) VALUES (1, '청소', current_timestamp());
-INSERT INTO section (job_id, name, created_at) VALUES (1, '트랙룸', current_timestamp());
-INSERT INTO task (section_id, name, created_at) VALUES (1, '책상 청소', current_timestamp());
-INSERT INTO task (section_id, name, created_at) VALUES (1, '빈백 털기', current_timestamp());
-INSERT INTO section (job_id, name, created_at) VALUES (1, '굿샷 강의장', current_timestamp());
-INSERT INTO task (section_id, name, created_at) VALUES (2, '책상 청소', current_timestamp());
-INSERT INTO task (section_id, name, created_at) VALUES (2, '의자 청소', current_timestamp());
+INSERT INTO host (space_password, github_id, image_url, created_at)
+VALUES ('1234', 2, 'test.com', current_timestamp());
+INSERT INTO space (host_id, name, created_at)
+VALUES (1, '잠실', current_timestamp());
+INSERT INTO job (space_id, name, created_at)
+VALUES (1, '청소', current_timestamp());
+INSERT INTO section (job_id, name, created_at)
+VALUES (1, '트랙룸', current_timestamp());
+INSERT INTO task (section_id, name, created_at)
+VALUES (1, '책상 청소', current_timestamp());
+INSERT INTO task (section_id, name, created_at)
+VALUES (1, '빈백 털기', current_timestamp());
+INSERT INTO section (job_id, name, created_at)
+VALUES (1, '굿샷 강의장', current_timestamp());
+INSERT INTO task (section_id, name, created_at)
+VALUES (2, '책상 청소', current_timestamp());
+INSERT INTO task (section_id, name, created_at)
+VALUES (2, '의자 청소', current_timestamp());

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -10,19 +10,21 @@ CREATE TABLE host
 (
     id             BIGINT     NOT NULL AUTO_INCREMENT,
     space_password VARCHAR(4) NOT NULL,
+    github_id      BIGINT     NOT NULL UNIQUE,
+    image_url      VARCHAR    NOT NULL,
     created_at     TIMESTAMP  NOT NULL,
-    updated_at     TIMESTAMP  NULL,
+    updated_at     TIMESTAMP NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE space
 (
     id         BIGINT      NOT NULL AUTO_INCREMENT,
-    host_id  BIGINT      NOT NULL,
+    host_id    BIGINT      NOT NULL,
     name       VARCHAR(20) NOT NULL,
-    img_url    VARCHAR     NULL,
+    img_url    VARCHAR NULL,
     created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP   NULL,
+    updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
 );
 
@@ -31,9 +33,9 @@ CREATE TABLE job
     id         BIGINT      NOT NULL AUTO_INCREMENT,
     space_id   BIGINT      NOT NULL,
     name       VARCHAR(20) NOT NULL,
-    slack_url  VARCHAR     NULL,
+    slack_url  VARCHAR NULL,
     created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP   NULL,
+    updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
 );
 
@@ -43,7 +45,7 @@ CREATE TABLE task
     section_id BIGINT      NOT NULL,
     name       VARCHAR(50) NOT NULL,
     created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP   NULL,
+    updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
 );
 
@@ -53,7 +55,7 @@ CREATE TABLE section
     job_id     BIGINT      NOT NULL,
     name       VARCHAR(20) NOT NULL,
     created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP   NULL,
+    updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## issue
- resolve #115 
- resolve #164 

## 코드 설명
- Github Oauth를 통해 로그인 기능을 구현하였습니다.
- Host entity에 github_id, image_url이 추가 되었습니다. 
    - (github_id : unique, not null & image_url : not null)
-> 그에 따른 테스트 코드 수정이 꽤 발생했습니다. 그렇게 복잡한 변화는 아니라 금방 파악할 수 있을 거에요!
- 로그인한 회원이 이미 존재하면 조회, 존재하지 않는 회원이면 생성합니다.
(생성 시 `Default SpacePassword`는 `0000`으로 설정하였습니다)
- host, guest별로 접근 가능한 api 판단을 위해 AuthenticationContext에 authority라는 추가적인 필드를 부여하였습니다. 

아래는 대략적인 OAuth 흐름입니다.

1. github에서 client_id, client_secret을 발급받는다.
2. https://github.com/login/oauth/authorize?client_id=${client_id} 를 통해 로그인에 성공하면 깃허브가 Authorization_code를 발급한다.
3. 클라이언트가 서버로 Authorization_code를 전달한다.
4. 서버는 github에게 client_id, client_secret, authorization_code를 전송한다.
5. github는 전달받은 데이터가 옳다면 서버측에 access_token을 발급한다.
6. 서버는 access_token을 통해 해당 사용자의 프로필을 요청한다.
7. github는 전달받은 토큰이 옳다면 서버측에 사용자의 프로필 정보를 반환한다.
8. 서버는 githubId를 통해 해당 유저가 존재하면 조회, 아니면 생성한다.
9. JwtTokenProvider를 사용해 해당 유저의 Id를 subject에 담아 토큰을 생성한다.
10. 토큰을 클라이언트에게 전달한다.


## 추가적으로 구현한 것
- git submodule을 이용해 중요 정보인 application-oauth.yml 파일을 숨겼습니다.
- 저희 gong-check organization의 private repository인 submodule에 해당 파일을 업로드 했습니다.
- 자세한 내용은 https://tecoble.techcourse.co.kr/post/2021-07-31-git-submodule/ 를 참고해주시면 감사하겠습니다!
