### PR TITLE
[BE] jacocoTestReport task 누락을 해결한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 tasks.named('asciidoctor') {


### PR DESCRIPTION
## issue
- resolve #153 

## 코드 설명
- `jacocoTestReport`가 실행되지 않아 SonarCloud에서 코드 커버리지에 대한 리포팅 메시지가 누락되어 전송됨
- `jacocoTestReport`가 `test` task 이후에 실행이 될 수 있도록 스크립트 수정
