### PR TITLE
[BE] Space 삭제, Space password 수정 API를 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostService.java
@@ -1,0 +1,23 @@
+package com.woowacourse.gongcheck.application;
+
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class HostService {
+
+    private final HostRepository hostRepository;
+
+    public HostService(final HostRepository hostRepository) {
+        this.hostRepository = hostRepository;
+    }
+
+    public void changeSpacePassword(final Long hostId, final SpacePasswordChangeRequest request) {
+        Host host = hostRepository.getById(hostId);
+        host.changeSpacePassword(request.getPassword());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -50,6 +50,10 @@ public class Host {
         }
     }
 
+    public void changeSpacePassword(final String spacePassword) {
+        this.spacePassword = spacePassword;
+    }
+
     private boolean isSameSpacePassword(final String password) {
         return spacePassword.equals(password);
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/job/JobRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/job/JobRepository.java
@@ -3,6 +3,7 @@ package com.woowacourse.gongcheck.domain.job;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,6 +14,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     Slice<Job> findBySpaceHostAndSpace(final Host host, final Space space, final Pageable pageable);
 
     Optional<Job> findBySpaceHostAndId(final Host host, final Long id);
+
+    List<Job> findAllBySpace(final Space space);
 
     default Job getBySpaceHostAndId(final Host host, final Long id) throws NotFoundException {
         return findBySpaceHostAndId(host, id)

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/section/SectionRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/section/SectionRepository.java
@@ -1,6 +1,9 @@
 package com.woowacourse.gongcheck.domain.section;
 
+import com.woowacourse.gongcheck.domain.job.Job;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+    List<Section> findAllByJob(final Job job);
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/TaskRepository.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.domain.task;
 
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.section.Section;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +16,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findAllBySectionJob(final Job job);
 
     Optional<Task> findBySectionJobSpaceHostAndId(final Host host, final Long id);
+
+    List<Task> findAllBySection(final Section section);
 
     default Task getBySectionJobSpaceHostAndId(final Host host, final Long id) throws NotFoundException {
         return findBySectionJobSpaceHostAndId(host, id)

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostController.java
@@ -1,0 +1,28 @@
+package com.woowacourse.gongcheck.presentation;
+
+import com.woowacourse.gongcheck.application.HostService;
+import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HostController {
+
+    private final HostService hostService;
+
+    public HostController(final HostService hostService) {
+        this.hostService = hostService;
+    }
+
+    @PatchMapping("/spacePassword")
+    public ResponseEntity<Void> changeSpacePassword(@AuthenticationPrincipal final Long hostId,
+                                                    @Valid @RequestBody final SpacePasswordChangeRequest request) {
+        hostService.changeSpacePassword(hostId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/SpaceController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/SpaceController.java
@@ -5,11 +5,12 @@ import com.woowacourse.gongcheck.application.response.SpacesResponse;
 import com.woowacourse.gongcheck.presentation.request.SpaceCreateRequest;
 import java.net.URI;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +37,12 @@ public class SpaceController {
                                             @Valid @ModelAttribute final SpaceCreateRequest request) {
         Long spaceId = spaceService.createSpace(hostId, request);
         return ResponseEntity.created(URI.create("/api/spaces/" + spaceId)).build();
+    }
+
+    @DeleteMapping("/spaces/{spaceId}")
+    public ResponseEntity<Void> removeSpace(@AuthenticationPrincipal final Long hostId,
+                                            @PathVariable final Long spaceId) {
+        spaceService.removeSpace(hostId, spaceId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SpacePasswordChangeRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SpacePasswordChangeRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.gongcheck.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class SpacePasswordChangeRequest {
+
+    private String password;
+
+    private SpacePasswordChangeRequest() {
+    }
+
+    public SpacePasswordChangeRequest(final String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SpacePasswordChangeRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/request/SpacePasswordChangeRequest.java
@@ -1,10 +1,14 @@
 package com.woowacourse.gongcheck.presentation.request;
 
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class SpacePasswordChangeRequest {
 
+    @Size(min = 4, max = 4, message = "비밀번호 길이가 올바르지 않습니다")
+    @Pattern(regexp = "[0-9]+", message = "비밀번호는 숫자로만 이루어져 있어야 합니다")
     private String password;
 
     private SpacePasswordChangeRequest() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
@@ -1,0 +1,34 @@
+package com.woowacourse.gongcheck.acceptance;
+
+import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
+
+import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
+import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class HostAcceptanceTest extends AcceptanceTest{
+
+    @Test
+    void 공간_비밀번호를_변경한다() {
+        // 호스트 로그인 구현 전까지 토큰 입력용으로 사용
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(new SpacePasswordChangeRequest("1234"))
+                .auth().oauth2(token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().patch("/api/spacePassword")
+                .then().log().all()
+                .extract();
+
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
@@ -80,4 +80,20 @@ class SpaceAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
+
+    @Test
+    void 공간을_삭제한다() {
+        // 호스트 로그인 구현 전까지 토큰 입력용으로 사용
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String token = 토큰을_요청한다(guestEnterRequest);
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().delete("/api/spaces/1")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
@@ -1,0 +1,39 @@
+package com.woowacourse.gongcheck.application;
+
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.exception.NotFoundException;
+import com.woowacourse.gongcheck.fixture.FixtureFactory;
+import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HostServiceTest {
+
+    @Autowired
+    private HostService hostService;
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Test
+    void SpacePassword를_변경한다() {
+        Host host = hostRepository.save(FixtureFactory.Host_생성("1234"));
+
+        String changedPassword = "4567";
+        hostService.changeSpacePassword(host.getId(), new SpacePasswordChangeRequest(changedPassword));
+
+        Assertions.assertThat(hostRepository.getById(host.getId()).getSpacePassword())
+                .isEqualTo(changedPassword);
+    }
+
+    @Test
+    void 존재하지_않는_Host의_SpacePassword를_변경하려는_경우_예외가_발생한다() {
+        Assertions.assertThatThrownBy(() -> hostService.changeSpacePassword(0L, new SpacePasswordChangeRequest("1234")))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 호스트입니다.");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/SpaceServiceTest.java
@@ -38,6 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 class SpaceServiceTest {
 
     @Autowired
+    EntityManager entityManager;
+
+    @Autowired
     private SpaceService spaceService;
 
     @Autowired
@@ -120,9 +123,6 @@ class SpaceServiceTest {
                     .hasMessage("존재하지 않는 호스트입니다.");
         }
     }
-
-    @Autowired
-    EntityManager entityManager;
 
     @Test
     void Space를_삭제하면_관련된_Job_Section_Task를_함께_삭제한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/DocumentationTest.java
@@ -4,6 +4,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 import com.woowacourse.gongcheck.application.GuestAuthService;
+import com.woowacourse.gongcheck.application.HostService;
 import com.woowacourse.gongcheck.application.ImageUploader;
 import com.woowacourse.gongcheck.application.JjwtTokenProvider;
 import com.woowacourse.gongcheck.application.JobService;
@@ -12,6 +13,7 @@ import com.woowacourse.gongcheck.application.SubmissionService;
 import com.woowacourse.gongcheck.application.TaskService;
 import com.woowacourse.gongcheck.presentation.AuthenticationContext;
 import com.woowacourse.gongcheck.presentation.GuestAuthController;
+import com.woowacourse.gongcheck.presentation.HostController;
 import com.woowacourse.gongcheck.presentation.JobController;
 import com.woowacourse.gongcheck.presentation.SpaceController;
 import com.woowacourse.gongcheck.presentation.SubmissionController;
@@ -32,7 +34,8 @@ import org.springframework.web.context.WebApplicationContext;
         SpaceController.class,
         JobController.class,
         TaskController.class,
-        SubmissionController.class
+        SubmissionController.class,
+        HostController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 class DocumentationTest {
@@ -53,6 +56,9 @@ class DocumentationTest {
 
     @MockBean
     protected SubmissionService submissionService;
+
+    @MockBean
+    protected HostService hostService;
 
     @MockBean
     protected JjwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
@@ -1,0 +1,65 @@
+package com.woowacourse.gongcheck.documentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class HostDocumentation extends DocumentationTest {
+
+    @Nested
+    class 비밀번호_변경 {
+
+        @Test
+        void 비밀번호_변경에_성공한다() {
+            doNothing().when(hostService).changeSpacePassword(anyLong(), any());
+            when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+            docsGiven
+                    .header("Authorization", "Bearer jwt.token.here")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(new SpacePasswordChangeRequest("1234"))
+                    .when().patch("/api/spacePassword")
+                    .then().log().all()
+                    .apply(document("host/update"))
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        void 비밀번호_길이가_맞지_않는_경우_변경에_실패한다() {
+            doNothing().when(hostService).changeSpacePassword(anyLong(), any());
+            when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+            docsGiven
+                    .header("Authorization", "Bearer jwt.token.here")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(new SpacePasswordChangeRequest("12345"))
+                    .when().patch("/api/spacePassword")
+                    .then().log().all()
+                    .apply(document("host/update"))
+                    .statusCode(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
+        void 비밀번호_형식이_맞지_않는_경우_변경에_실패한다() {
+            doNothing().when(hostService).changeSpacePassword(anyLong(), any());
+            when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+            docsGiven
+                    .header("Authorization", "Bearer jwt.token.here")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(new SpacePasswordChangeRequest("가나다라"))
+                    .when().patch("/api/spacePassword")
+                    .then().log().all()
+                    .apply(document("host/update"))
+                    .statusCode(HttpStatus.BAD_REQUEST.value());
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -4,6 +4,7 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -93,5 +94,18 @@ class SpaceDocumentation extends DocumentationTest {
                     .apply(document("spaces/create"))
                     .statusCode(HttpStatus.BAD_REQUEST.value());
         }
+    }
+
+    @Test
+    void 공간을_삭제한다() {
+        doNothing().when(spaceService).removeSpace(anyLong(), anyLong());
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        docsGiven
+                .header(AUTHORIZATION, "Bearer jwt.token.here")
+                .when().delete("/api/spaces/1")
+                .then().log().all()
+                .apply(document("spaces/delete"))
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
@@ -1,11 +1,10 @@
 package com.woowacourse.gongcheck.domain.host;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostTest.java
@@ -1,9 +1,11 @@
 package com.woowacourse.gongcheck.domain.host;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.gongcheck.exception.UnauthorizedException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -27,5 +29,17 @@ class HostTest {
         void 일치하면_예외가_발생하지_않는다() {
             assertDoesNotThrow(() -> host.checkPassword("0123"));
         }
+    }
+
+    @Test
+    void SpacePassword를_수정한다() {
+        Host host = Host.builder()
+                .spacePassword("1234")
+                .build();
+        String changedPassword = "4567";
+
+        host.changeSpacePassword(changedPassword);
+
+        assertThat(host.getSpacePassword()).isEqualTo(changedPassword);
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
@@ -70,4 +70,16 @@ class JobRepositoryTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
     }
+
+    @Test
+    void 입력된_Space에_등록된_모든_Job을_조회한다() {
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+        Job job1 = jobRepository.save(Job_생성(space, "청소"));
+        Job job2 = jobRepository.save(Job_생성(space, "마감"));
+
+        List<Job> result = jobRepository.findAllBySpace(space);
+
+        assertThat(result).containsExactly(job1, job2);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.woowacourse.gongcheck.domain.section;
+
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
+import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
+
+import com.woowacourse.gongcheck.domain.host.Host;
+import com.woowacourse.gongcheck.domain.host.HostRepository;
+import com.woowacourse.gongcheck.domain.job.Job;
+import com.woowacourse.gongcheck.domain.job.JobRepository;
+import com.woowacourse.gongcheck.domain.space.Space;
+import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class SectionRepositoryTest {
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Test
+    void 입력된_Job에_해당하는_모든_Section을_조회한다() {
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section1 = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Section section2 = sectionRepository.save(Section_생성(job, "굿샷 강의장"));
+
+        List<Section> result = sectionRepository.findAllByJob(job);
+
+        Assertions.assertThat(result).containsExactly(section1, section2);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
@@ -90,4 +90,18 @@ class TaskRepositoryTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 작업입니다.");
     }
+
+    @Test
+    void 입력받은_Section에_해당하는_모든_Task를_조회한다() {
+        Host host = hostRepository.save(Host_생성("1234"));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task1 = taskRepository.save(Task_생성(section, "책상 청소"));
+        Task task2 = taskRepository.save(Task_생성(section, "빈백 정리"));
+
+        List<Task> result = taskRepository.findAllBySection(section);
+
+        assertThat(result).containsExactly(task1, task2);
+    }
 }


### PR DESCRIPTION
## issue
- resolve #140 

## 코드 설명
- Space 삭제와 SpacePassword 수정 기능입니다.

Space 삭제의 경우 삭제하려는 Space와 연관된 Job Section, Task를 모두 조회한 후 삭제하는 방식으로 구현했습니다.

영속성 전이를 이용하여 삭제하려면 양방향 연관관계를 걸어줘야하는데 추후에 논의를 해봐야할 것 같습니다.

### 엔티티 매니저를 직접 호출해야하는 이슈

테스트에서 entityManager를 직접 호출하는 부분이 있습니다.

SpaceServiceTest.class
```java
    @Test
    void Space를_삭제하면_관련된_Job_Section_Task를_함께_삭제한다() {
        Host host = hostRepository.save(Host_생성("1234"));
        Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
        Job job = jobRepository.save(Job_생성(space, "청소"));
        Section section = sectionRepository.save(Section_생성(job, "대강의실"));
        Task task = taskRepository.save(Task_생성(section, "책상 닦기"));

        spaceService.removeSpace(host.getId(), space.getId());

        entityManager.flush();
        entityManager.clear();
        assertAll(
                () -> assertThat(spaceRepository.findById(space.getId())).isEmpty(),
                () -> assertThat(jobRepository.findById(job.getId())).isEmpty(),
                () -> assertThat(sectionRepository.findById(section.getId())).isEmpty(),
                () -> assertThat(taskRepository.findById(task.getId())).isEmpty()
        );
    }

```

저걸 안해주니까 `() -> assertThat(jobRepository.findById(job.getId())).isEmpty()` 이 부분에서 테스트가 터지더라구요.

로그를 확인해보면 delete job 쿼리가 분명 나가는데 DB에는 반영이 안되어있습니다. 관련 이슈에 대해 아시는 분은 코멘트 남겨주시면 감사하겠습니다.
