### PR TITLE
[FE] 사용자, 토큰 만료 시, 에러처리를 해야한다.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.27.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^3.1.4",
         "react-icons": "^4.4.0",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
@@ -12472,6 +12473,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-icons": {
@@ -26375,6 +26391,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-icons": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^3.1.4",
     "react-icons": "^4.4.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",

--- a/frontend/src/errorBoundary/ErrorUserToken.tsx
+++ b/frontend/src/errorBoundary/ErrorUserToken.tsx
@@ -1,0 +1,43 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { ErrorBoundary } from 'react-error-boundary';
+import { QueryErrorResetBoundary } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+
+const EXPIRED_TOKEN_TEXT = '만료된 토큰입니다.';
+const NOT_TOKEN_TEXT = '헤더에 토큰 값이 정상적으로 존재하지 않습니다.';
+
+interface ErrorUserTokenProps {
+  children: React.ReactNode;
+}
+
+const ErrorUserToken: React.FC<ErrorUserTokenProps> = ({ children }) => {
+  const navigate = useNavigate();
+  const { hostId } = useParams();
+
+  return (
+    <QueryErrorResetBoundary>
+      <ErrorBoundary
+        fallbackRender={({ error }) => {
+          const err = error as AxiosError;
+          const res = err.response as AxiosResponse;
+          const message = res.data.message;
+
+          if (message === EXPIRED_TOKEN_TEXT) {
+            localStorage.removeItem('user');
+            navigate(`/enter/${hostId}/pwd`);
+          }
+
+          if (message === NOT_TOKEN_TEXT) {
+            navigate(`/enter/${hostId}/pwd`);
+          }
+
+          return <></>;
+        }}
+      >
+        {children}
+      </ErrorBoundary>
+    </QueryErrorResetBoundary>
+  );
+};
+
+export default ErrorUserToken;

--- a/frontend/src/errorBoundary/ErrorUserToken.tsx
+++ b/frontend/src/errorBoundary/ErrorUserToken.tsx
@@ -22,12 +22,8 @@ const ErrorUserToken: React.FC<ErrorUserTokenProps> = ({ children }) => {
           const res = err.response as AxiosResponse;
           const message = res.data.message;
 
-          if (message === EXPIRED_TOKEN_TEXT) {
+          if (message === EXPIRED_TOKEN_TEXT || message === NOT_TOKEN_TEXT) {
             localStorage.removeItem('user');
-            navigate(`/enter/${hostId}/pwd`);
-          }
-
-          if (message === NOT_TOKEN_TEXT) {
             navigate(`/enter/${hostId}/pwd`);
           }
 

--- a/frontend/src/layouts/UserLayout/index.tsx
+++ b/frontend/src/layouts/UserLayout/index.tsx
@@ -1,12 +1,7 @@
+import ErrorUserToken from '@/errorBoundary/ErrorUserToken';
 import { css } from '@emotion/react';
-import { AxiosResponse, AxiosError } from 'axios';
 import { Suspense, useEffect } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
-import { QueryErrorResetBoundary } from 'react-query';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
-
-const EXPIRED_TOKEN_TEXT = '만료된 토큰입니다.';
-const NOT_TOKEN_TEXT = '헤더에 토큰 값이 정상적으로 존재하지 않습니다.';
 
 const UserLayout: React.FC = () => {
   const navigate = useNavigate();
@@ -19,41 +14,22 @@ const UserLayout: React.FC = () => {
   }, []);
 
   return (
-    <QueryErrorResetBoundary>
-      <ErrorBoundary
-        fallbackRender={({ error }) => {
-          const err = error as AxiosError;
-          const res = err.response as AxiosResponse;
-          const message = res.data.message;
-
-          if (message === EXPIRED_TOKEN_TEXT) {
-            localStorage.removeItem('user');
-            navigate(`/enter/${hostId}/pwd`);
-          }
-
-          if (message === NOT_TOKEN_TEXT) {
-            navigate(`/enter/${hostId}/pwd`);
-          }
-
-          return <></>;
-        }}
+    <ErrorUserToken>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          width: 400px;
+          min-height: 100vh;
+          background-color: white;
+          position: absolute;
+        `}
       >
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            width: 400px;
-            min-height: 100vh;
-            background-color: white;
-            position: absolute;
-          `}
-        >
-          <Suspense fallback={<div>로딩 스피너</div>}>
-            <Outlet />
-          </Suspense>
-        </div>
-      </ErrorBoundary>
-    </QueryErrorResetBoundary>
+        <Suspense fallback={<div>로딩 스피너</div>}>
+          <Outlet />
+        </Suspense>
+      </div>
+    </ErrorUserToken>
   );
 };
 


### PR DESCRIPTION
## issue
- resolve #161 

## 코드 설명
- 사용자(user) 토큰 관련 error boundary 구현
  - 토큰이 만료될 경우,토큰이 없을 경우
    - 로컬스토리지에 있는 토큰을 지우고 비밀번호 페이지로 이동한다.

### 관련 자료
- [error boundary props](https://github.com/bvaughn/react-error-boundary#errorboundary-props)
- [React ErrorBoundary 에러 핸들링 하기](https://velog.io/@rkd028/React-ErrorBoundary-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%EC%97%90%EB%9F%AC-%ED%95%B8%EB%93%A4%EB%A7%81-%ED%95%98%EA%B8%B0)
- [QueryErrorResetBoundary](https://tanstack.com/query/v4/docs/reference/QueryErrorResetBoundary?from=reactQueryV3&original=https://react-query-v3.tanstack.com/reference/QueryErrorResetBoundary)