### PR TITLE
[FE] API 호출 관련 로딩, 에러 처리를 한다.

### DIFF
--- a/frontend/src/ErrorBoundary/ErrorHostToken.tsx
+++ b/frontend/src/ErrorBoundary/ErrorHostToken.tsx
@@ -1,0 +1,37 @@
+import { AxiosError } from 'axios';
+import { ErrorBoundary } from 'react-error-boundary';
+import { QueryErrorResetBoundary } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+const EXPIRED_TOKEN_TEXT = '만료된 토큰입니다.';
+const NOT_TOKEN_TEXT = '헤더에 토큰 값이 정상적으로 존재하지 않습니다.';
+
+interface ErrorHostTokenProps {
+  children: React.ReactNode;
+}
+
+const ErrorHostToken: React.FC<ErrorHostTokenProps> = ({ children }) => {
+  const navigate = useNavigate();
+
+  return (
+    <QueryErrorResetBoundary>
+      <ErrorBoundary
+        fallbackRender={({ error }) => {
+          const err = error as AxiosError<{ message: string }>;
+          const message = err.response?.data.message;
+
+          if (message === EXPIRED_TOKEN_TEXT || message === NOT_TOKEN_TEXT) {
+            localStorage.removeItem('token');
+            navigate(`/host`);
+          }
+
+          return <></>;
+        }}
+      >
+        {children}
+      </ErrorBoundary>
+    </QueryErrorResetBoundary>
+  );
+};
+
+export default ErrorHostToken;

--- a/frontend/src/layouts/HostLayout/index.tsx
+++ b/frontend/src/layouts/HostLayout/index.tsx
@@ -1,3 +1,4 @@
+import ErrorHostToken from '@/ErrorBoundary/ErrorHostToken';
 import { Suspense, useMemo } from 'react';
 import { Outlet } from 'react-router-dom';
 
@@ -11,11 +12,13 @@ const HostLayout: React.FC = () => {
   const isManagePath = useMemo(() => location.pathname.includes(MANAGE_PATH), []);
 
   return (
-    <Suspense fallback={<Loading />}>
-      <div css={styles.layout(isManagePath)}>
-        <Outlet />
-      </div>
-    </Suspense>
+    <ErrorHostToken>
+      <Suspense fallback={<Loading />}>
+        <div css={styles.layout(isManagePath)}>
+          <Outlet />
+        </div>
+      </Suspense>
+    </ErrorHostToken>
   );
 };
 

--- a/frontend/src/layouts/ManageLayout/index.tsx
+++ b/frontend/src/layouts/ManageLayout/index.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import { useQuery } from 'react-query';
 import { Outlet } from 'react-router-dom';
 


### PR DESCRIPTION
## issue
- resolve #223 

## 코드 설명
- 관리자(host) 토큰이 유효하지 않을 경우 로그인 페이지로 이동한다.


고려할 사항
- react에서 다음과 같은 에러를 노출시키는데 DOM이 렌더링될때 다른 함수가 실행이되어서 발생하는 에러이다.
- 이런 에러를 처리하는 방법은 useEffect(사이드이펙트)로 함수를 실행시켜야 하는데 현재 에러 바운더리의 컴포넌트? 함수?를 실행시키는거라 잘 이해가 되지 않는다. 나중에 좀더 찾아 봐야겠다.
- 유저측 에러바운더리에서는 발생하지 않는다.
![스크린샷 2022-07-21 오전 10 13 04](https://user-images.githubusercontent.com/56149367/180110835-3014d3b9-45ad-4a38-9216-8b18d95cf5db.png)
 