### PR TITLE
[BE] 호스트 아이디 조회 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/host.adoc
+++ b/backend/src/docs/asciidoc/host.adoc
@@ -1,5 +1,0 @@
-[[Host]]
-== 호스트
-
-=== 호스트 비밀번호 변경
-operation::host/spacePassword_update/success[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/hosts.adoc
+++ b/backend/src/docs/asciidoc/hosts.adoc
@@ -1,0 +1,9 @@
+[[Hosts]]
+== 호스트
+
+=== 호스트 비밀번호 변경
+operation::hosts/spacePassword_update/success[snippets='http-request,http-response']
+
+
+=== 호스트 아이디 조회
+operation::hosts/find[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -7,7 +7,7 @@
 == Gong-Check
 
 include::guest.adoc[]
-include::host.adoc[]
+include::hosts.adoc[]
 include::space.adoc[]
 include::job.adoc[]
 include::task.adoc[]

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/HostService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/HostService.java
@@ -22,4 +22,8 @@ public class HostService {
         Host host = hostRepository.getById(hostId);
         host.changeSpacePassword(new SpacePassword(request.getPassword()));
     }
+
+    public Long getHostId(final Long hostId) {
+        return hostRepository.getById(hostId).getId();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/HostResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/HostResponse.java
@@ -1,0 +1,20 @@
+package com.woowacourse.gongcheck.application.response;
+
+import lombok.Getter;
+
+@Getter
+public class HostResponse {
+
+    private Long id;
+
+    private HostResponse() {
+    }
+
+    private HostResponse(final Long id) {
+        this.id = id;
+    }
+
+    public static HostResponse from(final Long id) {
+        return new HostResponse(id);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/presentation/HostController.java
@@ -1,10 +1,12 @@
 package com.woowacourse.gongcheck.presentation;
 
 import com.woowacourse.gongcheck.application.HostService;
+import com.woowacourse.gongcheck.application.response.HostResponse;
 import com.woowacourse.gongcheck.presentation.aop.HostOnly;
 import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +28,11 @@ public class HostController {
                                                     @Valid @RequestBody final SpacePasswordChangeRequest request) {
         hostService.changeSpacePassword(hostId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/hosts/me")
+    @HostOnly
+    public ResponseEntity<HostResponse> showHost(@AuthenticationPrincipal final Long hostId) {
+        return ResponseEntity.ok(HostResponse.from(hostService.getHostId(hostId)));
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
@@ -2,13 +2,13 @@ package com.woowacourse.gongcheck.acceptance;
 
 import static com.woowacourse.gongcheck.acceptance.AuthSupport.Host_토큰을_요청한다;
 import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청한다;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.gongcheck.presentation.request.GuestEnterRequest;
 import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,7 +28,7 @@ class HostAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
     @Test
@@ -44,6 +44,20 @@ class HostAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void Host_토큰으로_호스트_아이디를_조회한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .when().get("/api/hosts/me")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/HostServiceTest.java
@@ -1,13 +1,16 @@
 package com.woowacourse.gongcheck.application;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.host.SpacePassword;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import com.woowacourse.gongcheck.presentation.request.SpacePasswordChangeRequest;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,15 +33,40 @@ class HostServiceTest {
         String changedPassword = "4567";
         hostService.changeSpacePassword(host.getId(), new SpacePasswordChangeRequest(changedPassword));
 
-        Assertions.assertThat(hostRepository.getById(host.getId()).getSpacePassword())
+        assertThat(hostRepository.getById(host.getId()).getSpacePassword())
                 .isEqualTo(new SpacePassword(changedPassword));
     }
 
     @Test
     void 존재하지_않는_Host의_SpacePassword를_변경하려는_경우_예외가_발생한다() {
         SpacePasswordChangeRequest request = new SpacePasswordChangeRequest("1234");
-        Assertions.assertThatThrownBy(() -> hostService.changeSpacePassword(0L, request))
+        assertThatThrownBy(() -> hostService.changeSpacePassword(0L, request))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 호스트입니다.");
+    }
+
+    @Nested
+    class Host_아이디_조회 {
+
+        private Host host;
+
+        @BeforeEach
+        void setUp() {
+            host = hostRepository.save(Host_생성("1234", 1111L));
+        }
+
+        @Test
+        void 정상적으로_조회한다() {
+            Long hostId = host.getId();
+            Long result = hostService.getHostId(hostId);
+            assertThat(result).isEqualTo(hostId);
+        }
+
+        @Test
+        void Host가_존재하지_않는_경우_예외를_발생시킨다() {
+            assertThatThrownBy(() -> hostService.getHostId(0L))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("존재하지 않는 호스트입니다.");
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/application/JobServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/application/JobServiceTest.java
@@ -2,9 +2,6 @@ package com.woowacourse.gongcheck.application;
 
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Job_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
-import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.RunningTask_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
@@ -32,8 +29,6 @@ import com.woowacourse.gongcheck.presentation.request.SectionCreateRequest;
 import com.woowacourse.gongcheck.presentation.request.SlackUrlChangeRequest;
 import com.woowacourse.gongcheck.presentation.request.TaskCreateRequest;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
@@ -30,7 +30,7 @@ class HostDocumentation extends DocumentationTest {
                     .body(new SpacePasswordChangeRequest("1234"))
                     .when().patch("/api/spacePassword")
                     .then().log().all()
-                    .apply(document("host/spacePassword_update/success"))
+                    .apply(document("hosts/spacePassword_update/success"))
                     .statusCode(HttpStatus.NO_CONTENT.value());
         }
 
@@ -47,7 +47,7 @@ class HostDocumentation extends DocumentationTest {
                     .body(new SpacePasswordChangeRequest("12345"))
                     .when().patch("/api/spacePassword")
                     .then().log().all()
-                    .apply(document("host/spacePassword_update/fail/password_length"))
+                    .apply(document("hosts/spacePassword_update/fail/password_length"))
                     .statusCode(HttpStatus.BAD_REQUEST.value());
         }
 
@@ -64,8 +64,21 @@ class HostDocumentation extends DocumentationTest {
                     .body(new SpacePasswordChangeRequest("가나다라"))
                     .when().patch("/api/spacePassword")
                     .then().log().all()
-                    .apply(document("host/spacePassword_update/fail/password_pattern"))
+                    .apply(document("hosts/spacePassword_update/fail/password_pattern"))
                     .statusCode(HttpStatus.BAD_REQUEST.value());
         }
+    }
+
+    @Test
+    void 호스트_아이디를_조회한다() {
+        when(hostService.getHostId(anyLong())).thenReturn(1L);
+        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
+
+        docsGiven
+                .header("Authorization", "Bearer jwt.token.here")
+                .when().get("/api/hosts/me")
+                .then().log().all()
+                .apply(document("hosts/find"))
+                .statusCode(HttpStatus.OK.value());
     }
 }


### PR DESCRIPTION
## issue
- resolve #225 

## 코드 설명
- 호스트의 id를 조회할 수 있는 API입니다.
- adoc 문서 host -> hosts로 변경하였습니다.
