### PR TITLE
[BE] EnableJpaAuditing을 추가한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/application/JobService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/JobService.java
@@ -19,7 +19,6 @@ import com.woowacourse.gongcheck.presentation.request.JobCreateRequest;
 import com.woowacourse.gongcheck.presentation.request.SectionCreateRequest;
 import com.woowacourse.gongcheck.presentation.request.SlackUrlChangeRequest;
 import com.woowacourse.gongcheck.presentation.request.TaskCreateRequest;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -101,7 +100,6 @@ public class JobService {
         Job job = Job.builder()
                 .space(space)
                 .name(request.getName())
-                .createdAt(LocalDateTime.now())
                 .build();
         jobRepository.save(job);
         createSectionsAndTasks(request.getSections(), job);
@@ -116,7 +114,6 @@ public class JobService {
         Section section = Section.builder()
                 .job(job)
                 .name(sectionCreateRequest.getName())
-                .createdAt(LocalDateTime.now())
                 .build();
         sectionRepository.save(section);
         createTasks(sectionCreateRequest.getTasks(), section);
@@ -135,7 +132,6 @@ public class JobService {
         return Task.builder()
                 .section(section)
                 .name(taskCreateRequest.getName())
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/SpaceService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/SpaceService.java
@@ -17,7 +17,6 @@ import com.woowacourse.gongcheck.domain.task.Task;
 import com.woowacourse.gongcheck.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.presentation.request.SpaceCreateRequest;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.data.domain.Pageable;
@@ -68,7 +67,6 @@ public class SpaceService {
                 .host(host)
                 .name(request.getName())
                 .imageUrl(imageUrl)
-                .createdAt(LocalDateTime.now())
                 .build();
         return spaceRepository.save(space)
                 .getId();

--- a/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/application/response/GithubProfileResponse.java
@@ -2,7 +2,6 @@ package com.woowacourse.gongcheck.application.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.gongcheck.domain.host.Host;
-import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -32,7 +31,6 @@ public class GithubProfileResponse {
         return Host.builder()
                 .githubId(getGithubId())
                 .imageUrl(imageUrl)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/config/JpaConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.gongcheck.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/host/Host.java
@@ -6,15 +6,20 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "host")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Host {
@@ -35,9 +40,11 @@ public class Host {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/job/Job.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/job/Job.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,9 +16,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "job")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Job {
@@ -38,9 +43,11 @@ public class Job {
     @Column(name = "slack_url")
     private String slackUrl;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
@@ -61,7 +68,6 @@ public class Job {
         return Submission.builder()
                 .job(this)
                 .author(author)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/section/Section.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/section/Section.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,9 +15,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "section")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Section {
@@ -34,9 +39,11 @@ public class Section {
     @Column(name = "name", length = NAME_MAX_LENGTH, nullable = false)
     private String name;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/space/Space.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/space/Space.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,9 +15,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "space")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Space {
@@ -37,9 +42,11 @@ public class Space {
     @Column(name = "img_url")
     private String imageUrl;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/submission/Submission.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/submission/Submission.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,9 +15,12 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "submission")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Submission {
@@ -34,6 +38,7 @@ public class Submission {
     @Column(name = "author", length = AUTHOR_MAX_LENGTH, nullable = false)
     private String author;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/RunningTask.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -13,9 +14,12 @@ import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "running_task")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class RunningTask {
@@ -33,6 +37,7 @@ public class RunningTask {
     @ColumnDefault("false")
     private boolean isChecked;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/domain/task/Task.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,9 +16,13 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "task")
+@EntityListeners(AuditingEntityListener.class)
 @Builder
 @Getter
 public class Task {
@@ -38,9 +43,11 @@ public class Task {
     @Column(name = "name", length = NAME_MAX_LENGTH, nullable = false)
     private String name;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
@@ -61,7 +68,6 @@ public class Task {
         return RunningTask.builder()
                 .taskId(id)
                 .isChecked(false)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/host/HostRepositoryTest.java
@@ -4,18 +4,32 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class HostRepositoryTest {
 
     @Autowired
     private HostRepository hostRepository;
+
+    @Test
+    void 호스트_저장_시_생성시간이_저장된다() {
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Host host = hostRepository.save(Host.builder()
+                .githubId(1L)
+                .imageUrl("http://image.com")
+                .build());
+        assertThat(host.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void 아이디로_호스트를_조회한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/job/JobRepositoryTest.java
@@ -7,19 +7,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class JobRepositoryTest {
 
     @Autowired
@@ -30,6 +34,19 @@ class JobRepositoryTest {
 
     @Autowired
     private JobRepository jobRepository;
+
+    @Test
+    void Job_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Job job = jobRepository.save(Job.builder()
+                .space(space)
+                .name("청소")
+                .build());
+        assertThat(job.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void Host와_Space를_입력받아_연관되는_Job을_조회한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/section/SectionRepositoryTest.java
@@ -6,18 +6,22 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Section_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.job.JobRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class SectionRepositoryTest {
 
     @Autowired
@@ -31,6 +35,20 @@ class SectionRepositoryTest {
 
     @Autowired
     private SectionRepository sectionRepository;
+
+    @Test
+    void Section_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Section section = sectionRepository.save(Section.builder()
+                .job(job)
+                .name("트랙룸")
+                .build());
+        assertThat(section.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void 입력된_Job_목록에_해당하는_모든_Section을_조회한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceRepositoryTest.java
@@ -6,9 +6,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -17,10 +19,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class SpaceRepositoryTest {
 
     @Autowired
@@ -28,6 +32,18 @@ class SpaceRepositoryTest {
 
     @Autowired
     private SpaceRepository spaceRepository;
+
+    @Test
+    void Space_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Space space = spaceRepository.save(Space.builder()
+                .host(host)
+                .name("잠실")
+                .build());
+        assertThat(space.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void Host의_Space를_조회한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/space/SpaceTest.java
@@ -4,7 +4,6 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.gongcheck.domain.host.Host;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class SpaceTest {
@@ -17,7 +16,6 @@ class SpaceTest {
                 () -> Space.builder()
                         .host(host)
                         .name("123456789123467891234")
-                        .createdAt(LocalDateTime.now())
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("공간의 이름은 20자 이하여야합니다.");
@@ -31,7 +29,6 @@ class SpaceTest {
                 () -> Space.builder()
                         .host(host)
                         .name("")
-                        .createdAt(LocalDateTime.now())
                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("공간의 이름은 공백일 수 없습니다.");

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/submission/SubmissionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/submission/SubmissionRepositoryTest.java
@@ -7,20 +7,24 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Submission_생성
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.job.Job;
 import com.woowacourse.gongcheck.domain.job.JobRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class SubmissionRepositoryTest {
 
     @Autowired
@@ -34,6 +38,20 @@ class SubmissionRepositoryTest {
 
     @Autowired
     private SubmissionRepository submissionRepository;
+
+    @Test
+    void Submission_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Submission submission = submissionRepository.save(Submission.builder()
+                .job(job)
+                .author("어썸오")
+                .build());
+        assertThat(submission.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void 입력받은_Job_목록에_해당하는_Submission_목록을_조회한다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/RunningTaskRepositoryTest.java
@@ -8,6 +8,7 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Space_생성;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.job.Job;
@@ -16,6 +17,7 @@ import com.woowacourse.gongcheck.domain.section.Section;
 import com.woowacourse.gongcheck.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,8 +25,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class RunningTaskRepositoryTest {
 
     @Autowired
@@ -44,6 +48,21 @@ class RunningTaskRepositoryTest {
 
     @Autowired
     private RunningTaskRepository runningTaskRepository;
+
+    @Test
+    void RunningTask_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+        Task task = taskRepository.save(Task_생성(section, "책상 청소"));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        RunningTask runningTask = runningTaskRepository.save(RunningTask.builder()
+                .taskId(task.getId())
+                .build());
+        assertThat(runningTask.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Nested
     class RunningTask_조회_및_존재_확인 {

--- a/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/domain/task/TaskRepositoryTest.java
@@ -8,6 +8,7 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.gongcheck.config.JpaConfig;
 import com.woowacourse.gongcheck.domain.host.Host;
 import com.woowacourse.gongcheck.domain.host.HostRepository;
 import com.woowacourse.gongcheck.domain.job.Job;
@@ -17,12 +18,15 @@ import com.woowacourse.gongcheck.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.domain.space.Space;
 import com.woowacourse.gongcheck.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTest
+@Import(JpaConfig.class)
 class TaskRepositoryTest {
 
     @Autowired
@@ -39,6 +43,21 @@ class TaskRepositoryTest {
 
     @Autowired
     private TaskRepository taskRepository;
+
+    @Test
+    void Task_저장_시_생성시간이_저장된다() {
+        Host host = hostRepository.save(Host_생성("1234", 1234L));
+        Space space = spaceRepository.save(Space_생성(host, "잠실"));
+        Job job = jobRepository.save(Job_생성(space, "청소"));
+        Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+
+        LocalDateTime nowLocalDateTime = LocalDateTime.now();
+        Task task = taskRepository.save(Task.builder()
+                .section(section)
+                .name("책상 청소")
+                .build());
+        assertThat(task.getCreatedAt()).isAfter(nowLocalDateTime);
+    }
 
     @Test
     void Job이_가진_모든_Task를_조회한다() {


### PR DESCRIPTION
## issue
- resolve #244

## 코드 설명
- `LocalDateTime.now()`로 된 로직들 전부 jpa 어노테이션으로 수정 진행하였습니다.
- 테스트에서 `Import(JpaConfig.class)`가 계속 반복되는데 차후 테스트 격리 어노테이션을 만들게된다면 고려할 지점이 될 수 있겠네요
- 일반적으로 많이들 사용하는 `BaseTimeEntity`라는 상위클래스를 두고 상속하는 방식이 아닌 어노테이션을 각각에 전부 달아주었습니다. 서비스 목적마다 다르겠지만 굳이 수정날짜가 필요하지 않은 엔티티들도 존재하기 때문에 해당 방식은 저희 코드에는 맞지 않아 보이네요
