### PR TITLE
[FE] 유저, 선택된 공간에 따라 Navigation 컴포넌트에 해당 공간의 색깔이 달라져야 한다.

### DIFF
--- a/frontend/src/components/host/Navigation/index.tsx
+++ b/frontend/src/components/host/Navigation/index.tsx
@@ -1,5 +1,5 @@
 import { CgHomeAlt, CgGirl } from 'react-icons/cg';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import navigationLogo from '@/assets/navigationLogo.png';
 
@@ -17,6 +17,7 @@ interface NavigationProps {
 
 const Navigation: React.FC<NavigationProps> = ({ spaces }) => {
   const navigate = useNavigate();
+  const { spaceId } = useParams();
 
   const onClickSpace = (spaceId: number) => {
     navigate(`${spaceId}`);
@@ -45,12 +46,20 @@ const Navigation: React.FC<NavigationProps> = ({ spaces }) => {
       <div id="나의 공간 목록" css={styles.category}>
         <span css={styles.categoryTitle}>나의 공간 목록</span>
         <div css={styles.categoryList}>
-          {spaces?.map(space => (
-            <div css={styles.categoryTextWrapper} key={space.id} onClick={() => onClickSpace(space.id)}>
-              <CgHomeAlt size={20} />
-              <span>{space.name}</span>
-            </div>
-          ))}
+          {spaces?.map(space => {
+            const isSelectedSpace = space.id === Number(spaceId);
+
+            return (
+              <div
+                css={[styles.categoryTextWrapper, isSelectedSpace && styles.selectedTextWrapper]}
+                key={space.id}
+                onClick={() => onClickSpace(space.id)}
+              >
+                <CgHomeAlt size={20} />
+                <span>{space.name}</span>
+              </div>
+            );
+          })}
           <div css={styles.addNewSpace} onClick={onClickNewSpace}>
             <span>+ 새로운 공간 추가</span>
           </div>

--- a/frontend/src/components/host/Navigation/styles.ts
+++ b/frontend/src/components/host/Navigation/styles.ts
@@ -68,7 +68,15 @@ const categoryTextWrapper = css`
   }
 
   :hover {
-    background-color: ${theme.colors.lightSkyBlue};
+    background-color: ${theme.colors.gray200};
+  }
+`;
+const selectedTextWrapper = css`
+  background-color: ${theme.colors.blue300};
+  color: ${theme.colors.white};
+
+  :hover {
+    background-color: ${theme.colors.blue200};
   }
 `;
 
@@ -86,6 +94,16 @@ const addNewSpace = css`
   }
 `;
 
-const styles = { layout, logo, logoImage, category, categoryTitle, categoryList, categoryTextWrapper, addNewSpace };
+const styles = {
+  layout,
+  logo,
+  logoImage,
+  category,
+  categoryTitle,
+  categoryList,
+  categoryTextWrapper,
+  selectedTextWrapper,
+  addNewSpace,
+};
 
 export default styles;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -7,6 +7,8 @@ const theme = Object.freeze({
     skyblue: '#68c1f8',
     lightSkyBlue: '#f1f8fe',
     black: '#272727',
+    blue200: '#85f4ff',
+    blue300: '#00d7ff',
     gray100: '#f9fbfd',
     gray200: '#f5f5f5',
     gray300: '#d9d9d9',


### PR DESCRIPTION
## issue
- resolve #283 

## 코드 설명
- 선택된 공간을 네비게이션에서 색깔로 구분할 수 있다.


고려할 점
- DashBoard 페이지에서 네비게이션의 공간을 클릭하면 선택된 공간의 정보로 페이지를 구성하게 되는데, 다양한 API 호출이 동시에 일어나서 다음과 같은 이슈가 발생한다.
- 네비게이션에서 다른 공간을 선택하면 네비게이션에 존재하는 해당 공간의 배경 색깔이 변경되는게 `느리다`
- DashBoard에 있는 다른 컴포넌트들도 api를 호출해서 해당 컴포넌트를 렌더링 하는데 네비게이션의 공간 텍스트의 배경 색깔이 변경되는 것 보다 더 먼저 변경된다.
- 동시에 바뀌거나 네비게이션의 공간 텍스트 배경색깔이 먼저 변경되어야 하는데 이러한 문제가 발생하는 것은 데이터가 단방향으로 흘러야 하는데 여기저기서 필요에 의해 API를 fetch 하고 있는 점과 네비게이션이 동떨어져 있어서 이러한 문제가 발생하는 거 같다.

### 큰 이슈는 아니나, 추후 고려해보고 생각해볼만한 이슈이다.

![스크린샷 2022-07-26 오후 12 34 14](https://user-images.githubusercontent.com/56149367/180917558-06642c75-98e3-4fb5-8156-c083bf0bac57.png)

