### PR TITLE
[BE] 인수테스트에 cucumber를 적용하기 위한 환경을 설정한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -13,6 +13,7 @@ sourceCompatibility = '11'
 
 configurations {
     asciidoctorExtensions
+    cucumberRuntime.extendsFrom(implementation, testImplementation, runtimeOnly)
 }
 
 repositories {
@@ -45,6 +46,11 @@ dependencies {
     // rest-assured
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
     testImplementation 'io.rest-assured:spring-mock-mvc:4.4.0'
+
+    //cucumber
+    testImplementation 'io.cucumber:cucumber-java:6.10.4'
+    testImplementation 'io.cucumber:cucumber-spring:6.10.4'
+    testImplementation 'io.cucumber:cucumber-junit-platform-engine:6.10.4'
 
     // rest-docs
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -101,6 +107,25 @@ jacocoTestReport {
         html.enabled true
         xml.enabled true
     }
+}
+
+task acceptanceTest() {
+    dependsOn assemble, compileTestJava
+    doLast {
+        javaexec {
+            main = "io.cucumber.core.cli.Main"
+            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
+            args = [
+                    '--plugin', 'pretty',
+                    '--plugin', 'html:build/reports/cucumber/cucumber-report.html',
+                    '--glue', 'com.woowacourse.gongcheck',
+                    'src/test/resources/features']
+        }
+    }
+}
+
+check {
+    dependsOn(acceptanceTest)
 }
 
 sonarqube {

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
@@ -1,0 +1,33 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(scopeName = "cucumber-glue")
+public class AcceptanceContext {
+
+    public RequestSpecification request;
+    public Response response;
+
+    public AcceptanceContext() {
+        reset();
+    }
+
+    private void reset() {
+        request = null;
+        response = null;
+    }
+
+    public void invokeHttpPost(String path, Object data) {
+        request = RestAssured
+                .given().log().all()
+                .body(data).contentType(ContentType.JSON);
+        response = request.post(path);
+        response.then().log().all();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceStep.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceStep.java
@@ -1,0 +1,9 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AcceptanceStep {
+
+    @Autowired
+    public AcceptanceContext context;
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberBootstrap.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberBootstrap.java
@@ -1,0 +1,21 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import io.cucumber.java.Before;
+import io.cucumber.spring.CucumberContextConfiguration;
+import io.restassured.RestAssured;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@CucumberContextConfiguration
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public class CucumberBootstrap {
+
+    @LocalServerPort
+    private int port;
+
+    @Before
+    public void setPort() {
+        RestAssured.port = port;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberBootstrap.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberBootstrap.java
@@ -6,9 +6,11 @@ import io.restassured.RestAssured;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
 @CucumberContextConfiguration
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("test")
 public class CucumberBootstrap {
 
     @LocalServerPort

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberIntegrationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberIntegrationTest.java
@@ -1,0 +1,7 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class CucumberIntegrationTest {
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/steps/GuestAuthStepDefinitions.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/steps/GuestAuthStepDefinitions.java
@@ -1,0 +1,30 @@
+package com.woowacourse.gongcheck.cucumber.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.gongcheck.auth.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.auth.presentation.request.GuestEnterRequest;
+import com.woowacourse.gongcheck.cucumber.AcceptanceStep;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.http.HttpStatus;
+
+public class GuestAuthStepDefinitions extends AcceptanceStep {
+
+    @When("Space의 패스워드를 입력하면")
+    public void Space의_패스워드를_입력하면() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+
+        context.invokeHttpPost("/api/hosts/1/enter", guestEnterRequest);
+    }
+
+    @Then("엑세스 토큰을 받는다")
+    public void 엑세스_토큰을_받는다() {
+        assertAll(
+                () -> assertThat(context.response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(
+                        context.response.body().jsonPath().getObject(".", GuestTokenResponse.class)).isNotNull()
+        );
+    }
+}

--- a/backend/src/test/resources/features/enter.feature
+++ b/backend/src/test/resources/features/enter.feature
@@ -1,0 +1,5 @@
+Feature: Space 입장 기능
+
+  Scenario: Space 입장하기
+    When Space의 패스워드를 입력하면
+    Then 엑세스 토큰을 받는다


### PR DESCRIPTION
## issue
- resolve #184 

## 코드 설명

기본적인 환경 설정과 시나리오 코드 예시 하나를 추가했습니다.


### 이전에 cucumber task가 동작하지 않았던 이유.

저번에 함께 트러블슈팅을 할 때, H2 드라이버를 찾아올 수 없다는 에러가 발생했었는데요, 알고보니 큐컴버를 위한 클래스패스 설정에서 `runtimeOnly` 의존성이 설정이 안되어 있어서 그랬습니다.

아래와 같이 런타임 의존성도 패스에 추가하여 문제를 해결했습니다.

```groovy
configurations {
    cucumberRuntime.extendsFrom(implementation, testImplementation, runtimeOnly)
}

...
task acceptanceTest() {
    dependsOn assemble, compileTestJava
    doLast {
        javaexec {
            main = "io.cucumber.core.cli.Main"
            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
            args = [
                    '--plugin', 'pretty',
                    '--plugin', 'html:build/reports/cucumber/cucumber-report.html',
                    '--glue', 'com.woowacourse.gongcheck',
                    'src/test/resources/features']
        }
    }
}
```

### 빌드시 큐컴버 태스크가 돌아가지 않는 문제.

gradle에 `check`라는 task가 있습니다. 여기 해당 태스크를 추가하면 빌드할 때 함께 돌아갑니다. `build`는 `check`에 의존하고 있습니다.

관련 문서: https://docs.gradle.org/current/userguide/base_plugin.html#sec:base_tasks

### 기본 설정

`CucumberIntegrationTest`: JUnit이 테스트 패키지를 발견하기 위해서는 해당 패키지에 `@Cucumber` 애너테이션을 가진 클래스가 하나 있어야합니다. `@Cucumber`는 테스트 마커 애너테이션입니다.

`CucumberBootstrap`: 인수테스트를 할 때, 스프링 설정과 큐컴버 설정을 읽어오는 부트스트랩 클래스입니다.

`AcceptanceContext`: 큐컴버로 테스트를 작성할 때, Given, When, Then을 각각 다른 메서드로 정의합니다. 이때 다른 메서드에서 상태(ex. `io.restassured.response.Response`)를 공유할 수 있도록 전역적으로 상태를 관리하는 객체가 하나 필요합니다. 매 시나리오마다 새로 생성됩니다.

`AcceptanceStep`: StepDefinition을 작성할 때는 이 클래스를 상속받아 context를 통해 요청을 보내고 응답을 꺼내오면 됩니다.
