### PR TITLE
[BE] bootJar 실행 시 현재 어플리케이션에서 생성된 Restdocs를 포함하도록 수정한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,8 +92,15 @@ task createDocument(type: Copy) {
     into file("src/main/resources/static")
 }
 
+task displaceDocument(type: Copy) {
+    dependsOn asciidoctor
+
+    from ("${asciidoctor.outputDir}")
+    into ("build/resources/main/static")
+}
+
 bootJar {
-    dependsOn createDocument
+    dependsOn displaceDocument
 }
 
 jacocoTestReport {


### PR DESCRIPTION
## issue
- resolve #331 

## 코드 설명
- bootJar 진행 전 build 파일에 resource를 정상적으로 copy하도록 수정
