### PR TITLE
fix: 깃헙 oauth 정보 삭제

### DIFF
--- a/backend/src/main/resources/application-oauth.yml
+++ b/backend/src/main/resources/application-oauth.yml
@@ -1,7 +1,0 @@
-github:
-  client:
-    id: e78f7565dee502d18ca2
-    secret: 9c65a1ec0bab97abd312d22d8878a093a6bd6377
-  url:
-    token: https://github.com/login/oauth/access_token
-    profile: https://api.github.com/user


### PR DESCRIPTION
## issue
- resolve #340 

## 코드 설명
- application-oauth.yml 파일이 공개 저장소에 노출되어 다시 삭제하였습니다.
