### PR TITLE
[BE] Space 생성, 수정 시 File input을 제거하고 url을 받도록 수정한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/SpaceController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/SpaceController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,7 +42,7 @@ public class SpaceController {
     @PostMapping("/spaces")
     @HostOnly
     public ResponseEntity<Void> createSpace(@AuthenticationPrincipal final Long hostId,
-                                            @Valid @ModelAttribute final SpaceCreateRequest request) {
+                                            @Valid @RequestBody final SpaceCreateRequest request) {
         Long spaceId = spaceService.createSpace(hostId, request);
         return ResponseEntity.created(URI.create("/api/spaces/" + spaceId)).build();
     }
@@ -53,12 +54,11 @@ public class SpaceController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping(value = "/spaces/{spaceId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping("/spaces/{spaceId}")
     public ResponseEntity<Void> changeSpace(@AuthenticationPrincipal final Long hostId,
                                             @PathVariable final Long spaceId,
-                                            @Valid @RequestPart(value = "request") final SpaceChangeRequest request,
-                                            @RequestPart(required = false) final MultipartFile image) {
-        spaceService.changeSpace(hostId, spaceId, request, image);
+                                            @Valid @RequestBody final SpaceChangeRequest request) {
+        spaceService.changeSpace(hostId, spaceId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SpaceChangeRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SpaceChangeRequest.java
@@ -9,10 +9,13 @@ public class SpaceChangeRequest {
     @NotNull
     private String name;
 
+    private String imageUrl;
+
     private SpaceChangeRequest() {
     }
 
-    public SpaceChangeRequest(final String name) {
+    public SpaceChangeRequest(final String name, final String imageUrl) {
         this.name = name;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SpaceCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SpaceCreateRequest.java
@@ -11,13 +11,14 @@ public class SpaceCreateRequest {
     @NotNull
     @Size(min = 1, max = 20, message = "공간의 이름은 한글자 이상 20자 이하여야 합니다.")
     private String name;
-    private MultipartFile image;
+
+    private String imageUrl;
 
     private SpaceCreateRequest() {
     }
 
-    public SpaceCreateRequest(final String name, final MultipartFile image) {
+    public SpaceCreateRequest(final String name, final String imageUrl) {
         this.name = name;
-        this.image = image;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/SpaceAcceptanceTest.java
@@ -5,6 +5,7 @@ import static com.woowacourse.gongcheck.acceptance.AuthSupport.토큰을_요청�
 
 import com.woowacourse.gongcheck.auth.presentation.request.GuestEnterRequest;
 import com.woowacourse.gongcheck.core.presentation.request.SpaceChangeRequest;
+import com.woowacourse.gongcheck.core.presentation.request.SpaceCreateRequest;
 import io.restassured.RestAssured;
 import java.io.File;
 import java.io.IOException;
@@ -27,16 +28,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void Host_토큰으로_Space를_생성한다() throws IOException {
-        File fakeImage = File.createTempFile("temp", ".jpg");
-
+    void Host_토큰으로_Space를_생성한다() {
+        SpaceCreateRequest request = new SpaceCreateRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
         String token = Host_토큰을_요청한다().getToken();
 
         RestAssured
                 .given().log().all()
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("name", "잠실 캠퍼스")
-                .multiPart("image", fakeImage)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
                 .auth().oauth2(token)
                 .when().post("/api/spaces")
                 .then().log().all()
@@ -44,25 +43,22 @@ class SpaceAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void Host_토큰으로_한_Host가_이미_존재하는_이름의_Space를_생성하면_에러_응답을_반환한다() throws IOException {
-        File fakeImage = File.createTempFile("temp", ".jpg");
-
+    void Host_토큰으로_한_Host가_이미_존재하는_이름의_Space를_생성하면_에러_응답을_반환한다() {
+        SpaceCreateRequest request = new SpaceCreateRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
         String token = Host_토큰을_요청한다().getToken();
 
         RestAssured
                 .given().log().all()
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("name", "잠실 캠퍼스")
-                .multiPart("image", fakeImage)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
                 .auth().oauth2(token)
                 .when().post("/api/spaces")
                 .then().log().all();
 
         RestAssured
                 .given().log().all()
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("name", "잠실 캠퍼스")
-                .multiPart("image", fakeImage)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
                 .auth().oauth2(token)
                 .when().post("/api/spaces")
                 .then().log().all()
@@ -70,17 +66,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void Host_토큰으로_Space를_수정한다() throws IOException {
-        File fakeImage = File.createTempFile("temp", ".jpg");
-        SpaceChangeRequest request = new SpaceChangeRequest("잠실 캠퍼스");
-
+    void Host_토큰으로_Space를_수정한다() {
+        SpaceChangeRequest request = new SpaceChangeRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
         String token = Host_토큰을_요청한다().getToken();
 
         RestAssured
                 .given().log().all()
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("request", request, MediaType.APPLICATION_JSON_VALUE)
-                .multiPart("image", fakeImage)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
                 .auth().oauth2(token)
                 .when().put("/api/spaces/1")
                 .then().log().all()
@@ -124,16 +117,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void Guest_토큰으로_Space를_생성_시_예외가_발생한다() throws IOException {
-        File fakeImage = File.createTempFile("temp", ".jpg");
-
+    void Guest_토큰으로_Space를_생성_시_예외가_발생한다() {
+        SpaceCreateRequest request = new SpaceCreateRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
         String token = 토큰을_요청한다(new GuestEnterRequest("1234"));
 
         RestAssured
                 .given().log().all()
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("name", "잠실 캠퍼스")
-                .multiPart("image", fakeImage)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
                 .auth().oauth2(token)
                 .when().post("/api/spaces")
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -126,8 +126,7 @@ class SpaceServiceTest {
             void setUp() {
                 host = hostRepository.save(Host_생성("1234", 1234L));
                 Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
-                request = new SpaceCreateRequest(space.getName().getValue(),
-                        new MockMultipartFile("잠실 캠퍼스 사진", new byte[]{}));
+                request = new SpaceCreateRequest(space.getName().getValue(), "https://image.gongcheck.shop/123sdf5");
             }
 
             @Test
@@ -147,8 +146,7 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                request = new SpaceCreateRequest("이것은 유일한 Space이름",
-                        new MockMultipartFile("잠실 캠퍼스 사진", new byte[]{}));
+                request = new SpaceCreateRequest("이것은 유일한 Space이름", "https://image.gongcheck.shop/123sdf5");
             }
 
             @Test
@@ -168,8 +166,7 @@ class SpaceServiceTest {
             @BeforeEach
             void setUp() {
                 host = hostRepository.save(Host_생성("1234", 1234L));
-                request = new SpaceCreateRequest("이것은 유일한 Space이름",
-                        new MockMultipartFile("잠실 캠퍼스 사진", new byte[]{}));
+                request = new SpaceCreateRequest("이것은 유일한 Space이름", "https://image.gongcheck.shop/123sdf5");
             }
 
             @Test

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -13,6 +13,7 @@ import com.woowacourse.gongcheck.core.application.response.SpaceResponse;
 import com.woowacourse.gongcheck.core.application.response.SpacesResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.presentation.request.SpaceChangeRequest;
+import com.woowacourse.gongcheck.core.presentation.request.SpaceCreateRequest;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -51,16 +52,15 @@ class SpaceDocumentation extends DocumentationTest {
     class Space를_생성한다 {
 
         @Test
-        void Space_생성에_성공한다() throws IOException {
-            File fakeImage = File.createTempFile("temp", ".jpg");
+        void Space_생성에_성공한다() {
+            SpaceCreateRequest request = new SpaceCreateRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
             when(spaceService.createSpace(anyLong(), any())).thenReturn(1L);
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
             docsGiven
                     .header(AUTHORIZATION, "Bearer jwt.token.here")
-                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                    .param("name", "잠실 캠퍼스")
-                    .multiPart("image", fakeImage)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
                     .when().post("/api/spaces")
                     .then().log().all()
                     .apply(document("spaces/create/success"))
@@ -69,12 +69,14 @@ class SpaceDocumentation extends DocumentationTest {
 
         @Test
         void Space_이름이_null_인_경우_생성에_실패한다() {
+            SpaceCreateRequest request = new SpaceCreateRequest(null, "https://image.gongcheck.shop/123sdf5");
             when(spaceService.createSpace(anyLong(), any())).thenReturn(1L);
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
             docsGiven
                     .header(AUTHORIZATION, "Bearer jwt.token.here")
-                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
                     .when().post("/api/spaces")
                     .then().log().all()
                     .apply(document("spaces/create/fail/name_null"))
@@ -83,13 +85,14 @@ class SpaceDocumentation extends DocumentationTest {
 
         @Test
         void Space_이름이_빈_값_인_경우_생성에_실패한다() {
+            SpaceCreateRequest request = new SpaceCreateRequest("", "https://image.gongcheck.shop/123sdf5");
             when(spaceService.createSpace(anyLong(), any())).thenReturn(1L);
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
             docsGiven
                     .header(AUTHORIZATION, "Bearer jwt.token.here")
-                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                    .param("name", "")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
                     .when().post("/api/spaces")
                     .then().log().all()
                     .apply(document("spaces/create/fail/name_blank"))
@@ -120,24 +123,16 @@ class SpaceDocumentation extends DocumentationTest {
     @Nested
     class Space를_수정한다 {
 
-        public File fakeImage;
-
-        @BeforeEach
-        void setUp() throws IOException {
-            fakeImage = File.createTempFile("temp", ".jpg");
-        }
-
         @Test
         void Space_수정에_성공한다() {
-            SpaceChangeRequest request = new SpaceChangeRequest("잠실 캠퍼스");
-            doNothing().when(spaceService).changeSpace(anyLong(), anyLong(), any(), any());
+            SpaceChangeRequest request = new SpaceChangeRequest("잠실 캠퍼스", "https://image.gongcheck.shop/123sdf5");
+            doNothing().when(spaceService).changeSpace(anyLong(), anyLong(), any());
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
             docsGiven
                     .header(AUTHORIZATION, "Bearer jwt.token.here")
-                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                    .multiPart("request", request, MediaType.APPLICATION_JSON_VALUE)
-                    .multiPart("image", fakeImage)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
                     .when().put("/api/spaces/1")
                     .then().log().all()
                     .apply(document("spaces/change/success"))
@@ -146,15 +141,14 @@ class SpaceDocumentation extends DocumentationTest {
 
         @Test
         void Space_이름이_null_인_경우_수정에_실패한다() {
-            SpaceChangeRequest request = new SpaceChangeRequest(null);
-            doNothing().when(spaceService).changeSpace(anyLong(), anyLong(), any(), any());
+            SpaceChangeRequest request = new SpaceChangeRequest(null, "https://image.gongcheck.shop/123sdf5");
+            doNothing().when(spaceService).changeSpace(anyLong(), anyLong(), any());
             when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
             docsGiven
                     .header(AUTHORIZATION, "Bearer jwt.token.here")
-                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                    .multiPart("request", request, MediaType.APPLICATION_JSON_VALUE)
-                    .multiPart("image", fakeImage)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
                     .when().put("/api/spaces/1")
                     .then().log().all()
                     .apply(document("spaces/change/fail/name_null"))


### PR DESCRIPTION
## issue
- resolve #349 

## 코드 설명
- 이미지 업로드기능 제거로 인하여 생성, 수정 시 `MultipartFile`을 받는 로직을 전체 제거
- 따라서 json request에서 imageUrl을 받도록 수정

## 차후 필요 사항
- imageUrl에 대한 제한을 두고싶다라면 Url에 대한 dns 네임을 제한하는 것도 한가지 방법이 될 듯 함
