### PR TITLE
[BE] Service 테스트에 대한 구체적인 테스트 검증을 추가한다.

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -3,9 +3,10 @@ package com.woowacourse.gongcheck.core.application;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.host.HostRepository;
-import com.woowacourse.gongcheck.core.domain.host.SpacePassword;
 import com.woowacourse.gongcheck.core.presentation.request.SpacePasswordChangeRequest;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,8 @@ class HostServiceTest {
 
             private static final String ORIGIN_PASSWORD = "1234";
             private static final String CHANGING_PASSWORD = "4567";
+            private static final long GITHUB_ID = 1234L;
+
 
             private SpacePasswordChangeRequest spacePasswordChangeRequest;
             private Long hostId;
@@ -45,17 +48,20 @@ class HostServiceTest {
             @BeforeEach
             void setUp() {
                 spacePasswordChangeRequest = new SpacePasswordChangeRequest(CHANGING_PASSWORD);
-                hostId = hostRepository.save(Host_생성(ORIGIN_PASSWORD, 1234L))
+                hostId = hostRepository.save(Host_생성(ORIGIN_PASSWORD, GITHUB_ID))
                         .getId();
             }
 
             @Test
             void 패스워드를_수정한다() {
                 hostService.changeSpacePassword(hostId, spacePasswordChangeRequest);
-                SpacePassword actual = hostRepository.getById(hostId)
-                        .getSpacePassword();
+                Host actual = hostRepository.getById(hostId);
 
-                assertThat(actual.getValue()).isEqualTo(CHANGING_PASSWORD);
+                assertAll(
+                        () -> assertThat(actual.getSpacePassword().getValue()).isEqualTo(CHANGING_PASSWORD),
+                        () -> assertThat(actual.getGithubId()).isEqualTo(GITHUB_ID),
+                        () -> assertThat(actual.getId()).isEqualTo(hostId)
+                );
             }
         }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -41,7 +41,6 @@ class HostServiceTest {
             private static final String CHANGING_PASSWORD = "4567";
             private static final long GITHUB_ID = 1234L;
 
-
             private SpacePasswordChangeRequest spacePasswordChangeRequest;
             private Long hostId;
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -177,7 +177,6 @@ class SpaceServiceTest {
                 Space actual = spaceRepository.getById(spaceId);
 
                 assertAll(
-                        () -> assertThat(actual.getId()).isEqualTo(spaceId),
                         () -> assertThat(actual.getName().getValue()).isEqualTo(SPACE_NAME),
                         () -> assertThat(actual.getImageUrl()).isEqualTo(SPACE_IMAGE_URL)
                 );

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -160,25 +159,59 @@ class SpaceServiceTest {
         @Nested
         class 입력받은_Host가_존재하는_경우 {
 
+            private static final String SPACE_NAME = "이것은 유일한 Space이름";
+            private static final String SPACE_IMAGE_URL = "https://image.gongcheck.shop/123sdf5";
+
             private Host host;
             private SpaceCreateRequest request;
 
             @BeforeEach
             void setUp() {
                 host = hostRepository.save(Host_생성("1234", 1234L));
-                request = new SpaceCreateRequest("이것은 유일한 Space이름", "https://image.gongcheck.shop/123sdf5");
+                request = new SpaceCreateRequest(SPACE_NAME, SPACE_IMAGE_URL);
             }
 
             @Test
             void Space를_생성한다() {
                 Long spaceId = spaceService.createSpace(host.getId(), request);
-                assertThat(spaceId).isNotNull();
+                Space actual = spaceRepository.getById(spaceId);
+
+                assertAll(
+                        () -> assertThat(actual.getId()).isEqualTo(spaceId),
+                        () -> assertThat(actual.getName().getValue()).isEqualTo(SPACE_NAME),
+                        () -> assertThat(actual.getImageUrl()).isEqualTo(SPACE_IMAGE_URL)
+                );
             }
         }
     }
 
     @Nested
     class findSpace_메서드는 {
+
+        @Nested
+        class Space_목록이_존재하는_경우 {
+
+            private static final String SPACE_NAME = "잠실 캠퍼스";
+
+            private Host host;
+            private Space space;
+
+            @BeforeEach
+            void setUp() {
+                host = hostRepository.save(Host_생성("1234", 2345L));
+                space = spaceRepository.save(Space_생성(host, SPACE_NAME));
+            }
+
+            @Test
+            void Job_목록을_조회한다() {
+                SpaceResponse actual = spaceService.findSpace(host.getId(), space.getId());
+
+                assertAll(
+                        () -> assertThat(actual.getId()).isEqualTo(space.getId()),
+                        () -> assertThat(actual.getName()).isEqualTo(SPACE_NAME)
+                );
+            }
+        }
 
         @Nested
         class 입력받은_Host가_입력받은_Space를_가지고_있지_않은_경우 {
@@ -243,20 +276,25 @@ class SpaceServiceTest {
         @Nested
         class 입력받은_Host가_입력받은_Space를_소유하고_있는_경우 {
 
+            private static final String SPACE_NAME = "잠실 캠퍼스";
+
             private Host host;
             private Space space;
 
             @BeforeEach
             void setUp() {
                 host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+                space = spaceRepository.save(Space_생성(host, SPACE_NAME));
             }
 
             @Test
             void Space_응답을_반환한다() {
                 SpaceResponse actual = spaceService.findSpace(host.getId(), space.getId());
 
-                assertThat(actual.getName()).isEqualTo(space.getName().getValue());
+                assertAll(
+                        () -> assertThat(actual.getId()).isEqualTo(space.getId()),
+                        () -> assertThat(actual.getName()).isEqualTo(SPACE_NAME)
+                );
             }
         }
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -309,7 +309,8 @@ class SubmissionServiceTest {
         @Nested
         class 올바른_Host의_Space를_입력받는_경우 {
 
-            private static final String SUBMISSION_AUTHOR = "어썸오";
+            private static final String SUBMISSION_AUTHOR_1 = "어썸오";
+            private static final String SUBMISSION_AUTHOR_2 = "어썸오";
 
             private Host host;
             private Space space;
@@ -322,9 +323,9 @@ class SubmissionServiceTest {
                 space = spaceRepository.save(Space_생성(host, "잠실"));
                 job = jobRepository.save(Job_생성(space, "청소"));
                 request = PageRequest.of(0, 2);
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR));
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR));
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR));
+                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_1));
+                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_2));
+                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_2));
             }
 
             @Test
@@ -334,13 +335,13 @@ class SubmissionServiceTest {
                 assertAll(
                         () -> assertThat(actual.getSubmissions())
                                 .extracting(SubmissionResponse::getJobId)
-                                        .containsExactly(job.getId(), job.getId()),
+                                .containsExactly(job.getId(), job.getId()),
                         () -> assertThat(actual.getSubmissions())
                                 .extracting(SubmissionResponse::getJobName)
                                 .containsExactly(job.getName(), job.getName()),
                         () -> assertThat(actual.getSubmissions())
                                 .extracting(SubmissionResponse::getAuthor)
-                                .containsExactly(SUBMISSION_AUTHOR, SUBMISSION_AUTHOR),
+                                .containsExactly(SUBMISSION_AUTHOR_1, SUBMISSION_AUTHOR_2),
                         () -> assertThat(actual.isHasNext()).isTrue()
                 );
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
@@ -9,10 +9,14 @@ import static com.woowacourse.gongcheck.fixture.FixtureFactory.Task_생성;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.gongcheck.core.application.response.JobActiveResponse;
-import com.woowacourse.gongcheck.core.application.response.RunningTasksResponse;
+import com.woowacourse.gongcheck.core.application.response.RunningTaskResponse;
+import com.woowacourse.gongcheck.core.application.response.RunningTasksWithSectionResponse;
+import com.woowacourse.gongcheck.core.application.response.TaskResponse;
 import com.woowacourse.gongcheck.core.application.response.TasksResponse;
+import com.woowacourse.gongcheck.core.application.response.TasksWithSectionResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.domain.job.Job;
@@ -97,7 +101,15 @@ class TaskServiceTest {
                 taskService.createNewRunningTasks(host.getId(), job.getId());
                 List<RunningTask> actual = runningTaskRepository.findAllById(taskIds);
 
-                assertThat(actual).hasSize(2);
+                assertAll(
+                        () -> assertThat(actual)
+                                .extracting(RunningTask::isChecked)
+                                .containsExactly(false, false),
+                        () -> assertThat(actual)
+                                .extracting(RunningTask::getTaskId)
+                                .containsAll(taskIds),
+                        () -> assertThat(actual).hasSize(2)
+                );
             }
         }
 
@@ -331,17 +343,23 @@ class TaskServiceTest {
         @Nested
         class 존재하는_Host와_RunningTasks가_생성된_Job을_입력받은_경우 {
 
+            private static final String SECTION_NAME = "트랙룸";
+            private static final String TASK_NAME_1 = "책상 청소";
+            private static final String TASK_NAME_2 = "의자 넣기";
+            private static final int TASK_INDEX = 0;
+
             private Host host;
             private Job job;
+            private Section section;
 
             @BeforeEach
             void setUp() {
                 host = hostRepository.save(Host_생성("1234", 1234L));
                 Space space = spaceRepository.save(Space_생성(host, "잠실"));
                 job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
+                Section section = sectionRepository.save(Section_생성(job, SECTION_NAME));
                 List<Task> tasks = taskRepository.saveAll(List.of(
-                        Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                        Task_생성(section, TASK_NAME_1), Task_생성(section, TASK_NAME_2)));
                 runningTaskRepository.saveAll(tasks.stream()
                         .map(task -> RunningTask_생성(task.getId(), false))
                         .collect(toList()));
@@ -351,9 +369,18 @@ class TaskServiceTest {
 
             @Test
             void 정상적으로_RunningTasks를_조회한다() {
-                RunningTasksResponse actual = taskService.findRunningTasks(host.getId(), job.getId());
+                List<RunningTasksWithSectionResponse> actual = taskService.findRunningTasks(host.getId(), job.getId())
+                        .getSections();
+                List<RunningTaskResponse> actualTasks = actual.get(TASK_INDEX).getTasks();
 
-                assertThat(actual.getSections()).hasSize(1);
+                assertAll(
+                        () -> assertThat(actual)
+                                .extracting(RunningTasksWithSectionResponse::getName)
+                                .containsExactly(SECTION_NAME),
+                        () -> assertThat(actual).hasSize(1),
+                        () -> assertThat(actualTasks).extracting(RunningTaskResponse::getName)
+                                .containsExactly(TASK_NAME_1, TASK_NAME_2)
+                );
             }
         }
 
@@ -570,7 +597,7 @@ class TaskServiceTest {
                 Job job = jobRepository.save(Job_생성(space, "청소"));
                 Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
                 taskId = taskRepository.save(Task_생성(section, "책상 청소"))
-                    .getId();
+                        .getId();
             }
 
             @Test
@@ -588,6 +615,10 @@ class TaskServiceTest {
         @Nested
         class 존재하는_Host와_Job을_입력하는_경우 {
 
+            private static final String SECTION_NAME = "트랙룸";
+            private static final String TASK_NAME_1 = "책상 청소";
+            private static final String TASK_NAME_2 = "의자 넣기";
+
             private Host host;
             private Job job;
 
@@ -596,15 +627,22 @@ class TaskServiceTest {
                 host = hostRepository.save(Host_생성("1234", 1234L));
                 Space space = spaceRepository.save(Space_생성(host, "잠실"));
                 job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                Section section = sectionRepository.save(Section_생성(job, SECTION_NAME));
+                taskRepository.saveAll(List.of(Task_생성(section, TASK_NAME_1), Task_생성(section, TASK_NAME_2)));
             }
 
             @Test
             void 조회에_성공한다() {
                 TasksResponse actual = taskService.findTasks(host.getId(), job.getId());
+                TasksWithSectionResponse actualTaskWithSectionResponses = actual.getSections().get(0);
+                List<TaskResponse> actualTaskResponses = actualTaskWithSectionResponses.getTasks();
 
-                assertThat(actual.getSections()).hasSize(1);
+                assertAll(
+                        () -> assertThat(actualTaskWithSectionResponses.getName()).isEqualTo(SECTION_NAME),
+                        () -> assertThat(actualTaskResponses).extracting(TaskResponse::getName)
+                                .containsExactly(TASK_NAME_1, TASK_NAME_2),
+                        () -> assertThat(actual.getSections()).hasSize(1)
+                );
             }
         }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
@@ -107,8 +107,7 @@ class TaskServiceTest {
                                 .containsExactly(false, false),
                         () -> assertThat(actual)
                                 .extracting(RunningTask::getTaskId)
-                                .containsAll(taskIds),
-                        () -> assertThat(actual).hasSize(2)
+                                .containsAll(taskIds)
                 );
             }
         }
@@ -378,7 +377,8 @@ class TaskServiceTest {
                                 .extracting(RunningTasksWithSectionResponse::getName)
                                 .containsExactly(SECTION_NAME),
                         () -> assertThat(actual).hasSize(1),
-                        () -> assertThat(actualTasks).extracting(RunningTaskResponse::getName)
+                        () -> assertThat(actualTasks)
+                                .extracting(RunningTaskResponse::getName)
                                 .containsExactly(TASK_NAME_1, TASK_NAME_2)
                 );
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/domain/submission/SubmissionRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/domain/submission/SubmissionRepositoryTest.java
@@ -80,6 +80,8 @@ class SubmissionRepositoryTest {
         @Nested
         class Job들의_리스트를_입력받는_경우 {
 
+            private static final String SUBMISSION_AUTHOR = "어썸오";
+
             private List<Job> jobs;
             private PageRequest request;
 
@@ -90,8 +92,8 @@ class SubmissionRepositoryTest {
                 Job job_1 = jobRepository.save(Job_생성(space, "청소"));
                 Job job_2 = jobRepository.save(Job_생성(space, "마감"));
                 jobs = jobRepository.saveAll(List.of(job_1, job_2));
-                submissionRepository.saveAll(List.of(Submission_생성(job_1), Submission_생성(job_1),
-                        Submission_생성(job_2), Submission_생성(job_2)));
+                submissionRepository.saveAll(List.of(Submission_생성(job_1, SUBMISSION_AUTHOR), Submission_생성(job_1, SUBMISSION_AUTHOR),
+                        Submission_생성(job_2, SUBMISSION_AUTHOR), Submission_생성(job_2, SUBMISSION_AUTHOR)));
                 request = PageRequest.of(0, 2);
             }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/fixture/FixtureFactory.java
@@ -117,10 +117,10 @@ public class FixtureFactory {
                 .build();
     }
 
-    public static Submission Submission_생성(final Job job) {
+    public static Submission Submission_생성(final Job job, final String author) {
         return Submission.builder()
                 .job(job)
-                .author("어썸오")
+                .author(author)
                 .createdAt(LocalDateTime.now())
                 .build();
     }


### PR DESCRIPTION
## issue
- resolve #353 

## 코드 설명
- Service 테스트에서 Id가 notNull인지만 확인하는 등의 검증이 부족한 부분을 보완했습니다.
- 생성된 submission의 name이 올바른지도 검증하기 위해 `Submission_생성` 픽스쳐 메서드에 name을 주입 받는 것으로 수정했습니다.
- actual에서 get() 해온 변수명은 actual~로 지정했습니다 (ex. actual.getTasks() -> actualTasks)
