### PR TITLE
[FE] 공간 수정 후, DashBoard 페이지에 spaceInfo 정보가 바로 반영되지 않는 이슈를 해결한다.

### DIFF
--- a/frontend/src/components/host/ImageBox/useImageBox.ts
+++ b/frontend/src/components/host/ImageBox/useImageBox.ts
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const useImageBox = (imageUrl: string | undefined) => {
-  const [imageSrcUrl, setImageSrcUrl] = useState(imageUrl);
+  const [imageSrcUrl, setImageSrcUrl] = useState('');
 
   const onChangeImg = (e: React.FormEvent<HTMLInputElement>) => {
     const input = e.target as HTMLInputElement;
@@ -15,6 +15,12 @@ const useImageBox = (imageUrl: string | undefined) => {
 
     setImageSrcUrl(src);
   };
+
+  useEffect(() => {
+    if (imageUrl) {
+      setImageSrcUrl(imageUrl);
+    }
+  }, [imageUrl]);
 
   return { imageSrcUrl, onChangeImg };
 };

--- a/frontend/src/components/host/SpaceInfo/index.tsx
+++ b/frontend/src/components/host/SpaceInfo/index.tsx
@@ -12,7 +12,7 @@ interface SpaceInfoProps {
 }
 
 const SpaceInfo: React.FC<SpaceInfoProps> = ({ type = 'read', inputText = '', data }) => {
-  const { isActiveSubmit, onChangeSpaceName, onClickEditSpaceInfo } = useSpaceInfo(data, type);
+  const { name, imageUrl, isActiveSubmit, onChangeSpaceName, onClickEditSpaceInfo } = useSpaceInfo(data, type);
 
   return (
     <div css={styles.spaceInfo}>
@@ -31,21 +31,21 @@ const SpaceInfo: React.FC<SpaceInfoProps> = ({ type = 'read', inputText = '', da
       <div css={styles.imageContainer}>
         <p css={styles.subTitle}>대표이미지</p>
         <div css={styles.imageWrapper}>
-          <ImageBox type={type} imageUrl={data?.imageUrl} />
+          <ImageBox type={type} imageUrl={imageUrl} />
         </div>
       </div>
       <div css={styles.inputContainer}>
         <div css={styles.inputWrapper}>
           <p css={styles.subTitle}>공간 이름</p>
           {type === 'read' ? (
-            <input css={styles.input} name="nameInput" type="text" defaultValue={data?.name} readOnly />
+            <input css={styles.input} name="nameInput" type="text" value={name} readOnly />
           ) : (
             <input
               css={styles.input}
               name="nameInput"
               placeholder="이름을 입력하세요"
               type="text"
-              defaultValue={data?.name || inputText || ''}
+              defaultValue={name || inputText || ''}
               onChange={onChangeSpaceName}
               required
             />

--- a/frontend/src/components/host/SpaceInfo/useSpaceInfo.ts
+++ b/frontend/src/components/host/SpaceInfo/useSpaceInfo.ts
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const useSpaceInfo = (data?: { name: string; imageUrl: string; id: number }, type?: 'read' | 'create' | 'update') => {
   const navigate = useNavigate();
+  const [name, setName] = useState<string | undefined>('');
 
   const [isActiveSubmit, setIsActiveSubmit] = useState(type === 'update');
 
@@ -17,7 +18,13 @@ const useSpaceInfo = (data?: { name: string; imageUrl: string; id: number }, typ
     navigate(`/host/manage/${data?.id}/spaceUpdate`);
   };
 
-  return { isActiveSubmit, onChangeSpaceName, onClickEditSpaceInfo };
+  useEffect(() => {
+    if (data?.name) {
+      setName(data?.name);
+    }
+  }, [data]);
+
+  return { name, imageUrl: data?.imageUrl, isActiveSubmit, onChangeSpaceName, onClickEditSpaceInfo };
 };
 
 export default useSpaceInfo;

--- a/frontend/src/pages/host/DashBoard/useDashBoard.tsx
+++ b/frontend/src/pages/host/DashBoard/useDashBoard.tsx
@@ -20,8 +20,10 @@ const useDashBoard = () => {
   const { openModal } = useModal();
   const { openToast } = useToast();
 
-  const { data: spaceData } = useQuery(['spaceDashBoard', spaceId], () => apiSpace.getSpace(spaceId), {
+  const { data: spaceData } = useQuery(['space', spaceId], () => apiSpace.getSpace(spaceId), {
     suspense: true,
+    staleTime: 0,
+    cacheTime: 0,
   });
   const { data: jobsData } = useQuery(['jobs', spaceId], () => apiJobs.getJobs(spaceId), { suspense: true });
   const { data: submissionData } = useQuery(['submissions', spaceId], () => apiSubmission.getSubmission({ spaceId }), {

--- a/frontend/src/pages/host/DashBoard/useDashBoard.tsx
+++ b/frontend/src/pages/host/DashBoard/useDashBoard.tsx
@@ -20,7 +20,9 @@ const useDashBoard = () => {
   const { openModal } = useModal();
   const { openToast } = useToast();
 
-  const { data: spaceData } = useQuery(['space', spaceId], () => apiSpace.getSpace(spaceId), { suspense: true });
+  const { data: spaceData } = useQuery(['spaceDashBoard', spaceId], () => apiSpace.getSpace(spaceId), {
+    suspense: true,
+  });
   const { data: jobsData } = useQuery(['jobs', spaceId], () => apiJobs.getJobs(spaceId), { suspense: true });
   const { data: submissionData } = useQuery(['submissions', spaceId], () => apiSubmission.getSubmission({ spaceId }), {
     suspense: true,

--- a/frontend/src/pages/host/SpaceUpdate/index.tsx
+++ b/frontend/src/pages/host/SpaceUpdate/index.tsx
@@ -12,7 +12,7 @@ import styles from './styles';
 const SpaceUpdate: React.FC = () => {
   const { spaceId } = useParams();
 
-  const { data } = useQuery(['spaceUpdate', spaceId], () => apiSpace.getSpace(spaceId), { suspense: true });
+  const { data } = useQuery(['space', spaceId], () => apiSpace.getSpace(spaceId), { suspense: true });
 
   const { onSubmitUpdateSpace } = useSpaceForm();
 

--- a/frontend/src/pages/host/SpaceUpdate/index.tsx
+++ b/frontend/src/pages/host/SpaceUpdate/index.tsx
@@ -12,7 +12,7 @@ import styles from './styles';
 const SpaceUpdate: React.FC = () => {
   const { spaceId } = useParams();
 
-  const { data } = useQuery(['space', spaceId], () => apiSpace.getSpace(spaceId), { suspense: true });
+  const { data } = useQuery(['spaceUpdate', spaceId], () => apiSpace.getSpace(spaceId), { suspense: true });
 
   const { onSubmitUpdateSpace } = useSpaceForm();
 


### PR DESCRIPTION
## issue
- resolve #369 

## 코드 설명
- 컴포넌트가 이전의 상태값을 계속 유지 해서 생기는 이슈였습니다.
- 상태값을 따로 빼서 SideEffect로 관리 했습니다.
- 그리고 useQuery key값이 페이지 마다 중복되어 이전의 값을 가져와서 key값을 변경했습니다.
