### PR TITLE
[FE] 사용자 password 페이지 화면 수정

### DIFF
--- a/frontend/src/pages/user/Password/index.tsx
+++ b/frontend/src/pages/user/Password/index.tsx
@@ -11,8 +11,8 @@ const Password: React.FC = () => {
 
   return (
     <div css={styles.layout}>
-      <div>
-        <img css={styles.homeCoverImage} src={homeCover} alt="공책 아이콘" />
+      <div css={styles.homeCoverImage}>
+        <img src={homeCover} alt="공책" />
       </div>
       <div css={styles.textWrapper}>
         <p>비밀번호를 입력해주세요.</p>

--- a/frontend/src/pages/user/Password/styles.ts
+++ b/frontend/src/pages/user/Password/styles.ts
@@ -9,6 +9,9 @@ const layout = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  @media screen and (max-width: 389px) {
+    font-size: 14px;
+  }
   font-size: 16px;
 `;
 const homeCoverImage = css`
@@ -17,7 +20,7 @@ const homeCoverImage = css`
   align-items: center;
 
   img {
-    width: 20em;
+    width: 22em;
   }
 `;
 
@@ -31,8 +34,9 @@ const textWrapper = css`
   }
 
   p:nth-of-type(1) {
+    margin-top: 12px;
     font-weight: bold;
-    font-size: 1.5em;
+    font-size: 1.4em;
   }
   p:nth-of-type(2) {
     font-size: 1em;
@@ -47,7 +51,7 @@ const textWrapper = css`
 const form = ({ isActiveSubmit }: { isActiveSubmit: boolean }) => css`
   display: flex;
   flex-direction: column;
-  margin-top: 2.4rem;
+  margin-top: 1.5rem;
   width: 15em;
 
   input {
@@ -64,6 +68,7 @@ const form = ({ isActiveSubmit }: { isActiveSubmit: boolean }) => css`
 
   input,
   button {
+    font-size: 1em;
     width: 100%;
     height: 3em;
     margin: 0.6em 0;

--- a/frontend/src/pages/user/Password/styles.ts
+++ b/frontend/src/pages/user/Password/styles.ts
@@ -4,13 +4,21 @@ import theme from '@/styles/theme';
 
 const layout = css`
   width: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
   font-size: 16px;
 `;
 const homeCoverImage = css`
-  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  img {
+    width: 20em;
+  }
 `;
 
 const textWrapper = css`
@@ -39,7 +47,7 @@ const textWrapper = css`
 const form = ({ isActiveSubmit }: { isActiveSubmit: boolean }) => css`
   display: flex;
   flex-direction: column;
-  margin: 3rem 0;
+  margin-top: 2.4rem;
   width: 15em;
 
   input {
@@ -58,7 +66,7 @@ const form = ({ isActiveSubmit }: { isActiveSubmit: boolean }) => css`
   button {
     width: 100%;
     height: 3em;
-    margin: 1em 0;
+    margin: 0.6em 0;
     padding: 1em;
     border-radius: 12px;
   }


### PR DESCRIPTION
## issue
- resolve #291 

## 코드 설명
- 실제 릴리즈 환경에서 유저가 password 입력에서 불편함을 느끼지않도록 화면 고려
기존 - SE 환경(* 실제 모바일 환경에서는 브라우저바가 있기때문에 더 가려짐)
<img width="550" alt="스크린샷 2022-08-03 01 33 44" src="https://user-images.githubusercontent.com/62434898/182430618-0fb5b198-cc1f-4c6d-991a-703603f825e4.png">
변경 - SE 환경
<img width="550" alt="스크린샷 2022-08-03 01 52 42" src="https://user-images.githubusercontent.com/62434898/182431025-9b16e769-fc6b-44df-8de8-223c8bf70431.png">

