### PR TITLE
feat: Job 생성, 수정 RestDocs에 누락된 필드를 추가

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -100,8 +100,16 @@ class JobDocumentation extends DocumentationTest {
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름"),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
                                             .description("Section 이름"),
+                                    fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
+                                            .description("Section 설명"),
+                                    fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
+                                            .description("Section Image Url"),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름")
+                                            .description("Task 이름"),
+                                    fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
+                                            .description("Task 설명"),
+                                    fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
+                                            .description("Task Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -206,8 +214,16 @@ class JobDocumentation extends DocumentationTest {
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름"),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
                                             .description("Section 이름"),
+                                    fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
+                                            .description("Section 설명"),
+                                    fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
+                                            .description("Section Image Url"),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름")
+                                            .description("Task 이름"),
+                                    fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
+                                            .description("Task 설명"),
+                                    fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
+                                            .description("Task Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());


### PR DESCRIPTION
## issue
- resolve #378 

## 코드 설명
- Job 수정, 생성 시 Restdocs 문서화에 누락된 ImageUrl, Description 필드를 추가하였습니다.
