### PR TITLE
[FE] 사용자 체크리스트 api 호출 시, 응답받은 imageUrl, description 데이터를 화면에 렌더링 해야한다.

### DIFF
--- a/frontend/src/components/user/TaskCard/index.tsx
+++ b/frontend/src/components/user/TaskCard/index.tsx
@@ -29,11 +29,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ tasks, getSections }) => {
   };
 
   const onClickTaskDetail = (task: any) => {
-    // TODO: api 명세서 나오면 알맞는 데이터를 넣을 생각입니다.
-    const imageUrl = 'https://velog.velcdn.com/images/cks3066/post/258f92c1-32be-4acb-be30-1eb64635c013/image.jpg';
-    const description = '어쩌고 저쩌고저쩌고............ㅇㅇㅇㅇ';
-
-    openModal(<DetailedInfoCardModal name={task.name} imageUrl={imageUrl} description={description} />);
+    openModal(<DetailedInfoCardModal name={task.name} imageUrl={task.imageUrl} description={task.description} />);
   };
 
   return (
@@ -47,7 +43,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ tasks, getSections }) => {
           />
           <div css={styles.textWrapper}>
             <span>{task.name}</span>
-            <RiInformationLine css={styles.icon} size={20} onClick={() => onClickTaskDetail(task)} />
+            {(task.imageUrl || task.description) && (
+              <RiInformationLine css={styles.icon} size={20} onClick={() => onClickTaskDetail(task)} />
+            )}
           </div>
         </div>
       ))}

--- a/frontend/src/pages/user/TaskList/index.tsx
+++ b/frontend/src/pages/user/TaskList/index.tsx
@@ -10,10 +10,8 @@ import useSectionCheck from '@/hooks/useSectionCheck';
 import styles from './styles';
 
 const TaskList: React.FC = () => {
-
   const { locationState, sectionsData, spaceData, getSections, onClickButton, goPreviousPage, onClickSectionDetail } =
     useTaskList();
-
 
   if (!sectionsData || !spaceData) return <></>;
 
@@ -44,17 +42,18 @@ const TaskList: React.FC = () => {
               <section css={styles.location} key={section.id}>
                 <div css={styles.locationHeader}>
                   <p css={styles.locationName}>{section.name}</p>
-                  {/* TODO: 해당 section에 상세 정보 유무에 따라 SectionInfoPreviewBox 노출해야한다.*/}
-                  <SectionInfoPreviewBox
-                    imageUrl={spaceData.imageUrl}
-                    onClick={() =>
-                      onClickSectionDetail({
-                        name: section.name,
-                        imageUrl: spaceData.imageUrl,
-                        description: '어쩌고 저쩌고 이렇고 저렇고....아아아아콜라',
-                      })
-                    }
-                  />
+                  {(section.imageUrl || section.description) && (
+                    <SectionInfoPreviewBox
+                      imageUrl={section.imageUrl}
+                      onClick={() =>
+                        onClickSectionDetail({
+                          name: section.name,
+                          imageUrl: section.imageUrl,
+                          description: section.description,
+                        })
+                      }
+                    />
+                  )}
                 </div>
                 <TaskCard tasks={section.tasks} getSections={getSections} />
               </section>


### PR DESCRIPTION
## issue
- resolve #380 

## 코드 설명
- 각 section, task의 imageUrl, description 유무에 따라 해당 컴포넌트 노출 유무를 결정한다.
- 각 section, task의 imageUrl, description 데이터로 모달을 노출한다.
