### PR TITLE
[FE] 서버에서 주는 에러메시지의 text를 정확히 체크 해야 한다.

### DIFF
--- a/frontend/src/ErrorBoundary/ErrorUserTask.tsx
+++ b/frontend/src/ErrorBoundary/ErrorUserTask.tsx
@@ -11,7 +11,7 @@ const NOT_TASK_TEXT = '존재하지 않는 작업입니다.';
 
 // 사용자들이 체크리스트 페이지에 접속 중일 때, 다른 사용자가 체크리시트를 제출 한 경우 발생
 const NOT_JOB_TEXT = '작업이 존재하지 않습니다.';
-const NOT_JOB_WORK = '현재 진행중인 작업이 존재하지 않아 조회할 수 없습니다.';
+const NOT_JOB_WORK_TEXT = '현재 진행중인 작업이 존재하지 않아 조회할 수 없습니다';
 
 interface ErrorUserTaskProps {
   children: React.ReactNode;

--- a/frontend/src/ErrorBoundary/ErrorUserTask.tsx
+++ b/frontend/src/ErrorBoundary/ErrorUserTask.tsx
@@ -30,7 +30,7 @@ const ErrorUserTask: React.FC<ErrorUserTaskProps> = ({ children }) => {
       navigate(`/enter/${hostId}/spaces`);
     }
 
-    if (message === NOT_JOB_TEXT || message === NOT_JOB_WORK) {
+    if (message === NOT_JOB_TEXT || message === NOT_JOB_WORK_TEXT) {
       openToast('ERROR', `다른 사용자가 체크리시트를 제출 했습니다. 공간 선택 페이지로 이동합니다.`);
       navigate(`/enter/${hostId}/spaces`);
     }


### PR DESCRIPTION
## issue
- resolve #401 

# 어떤 에러 메시지는 `.`이 있고 어떤 에러 메시지는 `.`이 없고...

![스크린샷 2022-08-04 오후 1 23 48](https://user-images.githubusercontent.com/56149367/182763594-87bb8f37-3fd8-4c75-9246-6d9a2b246112.png)

