### PR TITLE
 [BE] 외부 라이브러리에 종속적인 코드/네이밍을 수정한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/application/HostAuthService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/application/HostAuthService.java
@@ -2,7 +2,7 @@ package com.woowacourse.gongcheck.auth.application;
 
 import static com.woowacourse.gongcheck.auth.domain.Authority.HOST;
 
-import com.woowacourse.gongcheck.auth.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.auth.application.response.SocialProfileResponse;
 import com.woowacourse.gongcheck.auth.application.response.TokenResponse;
 import com.woowacourse.gongcheck.auth.presentation.request.TokenRequest;
 import com.woowacourse.gongcheck.core.domain.host.Host;
@@ -28,17 +28,17 @@ public class HostAuthService {
 
     @Transactional
     public TokenResponse createToken(final TokenRequest request) {
-        GithubProfileResponse githubProfileResponse = githubOauthClient.requestGithubProfileByCode(request.getCode());
-        boolean alreadyJoin = hostRepository.existsByGithubId(githubProfileResponse.getGithubId());
-        Host host = findOrCreateHost(alreadyJoin, githubProfileResponse);
+        SocialProfileResponse socialProfileResponse = githubOauthClient.requestSocialProfileByCode(request.getCode());
+        boolean alreadyJoin = hostRepository.existsByGithubId(socialProfileResponse.getGithubId());
+        Host host = findOrCreateHost(alreadyJoin, socialProfileResponse);
         String token = jwtTokenProvider.createToken(String.valueOf(host.getId()), HOST);
         return TokenResponse.of(token, alreadyJoin);
     }
 
-    private Host findOrCreateHost(final boolean alreadyJoin, final GithubProfileResponse githubProfileResponse) {
+    private Host findOrCreateHost(final boolean alreadyJoin, final SocialProfileResponse socialProfileResponse) {
         if (alreadyJoin) {
-            return hostRepository.getByGithubId(githubProfileResponse.getGithubId());
+            return hostRepository.getByGithubId(socialProfileResponse.getGithubId());
         }
-        return hostRepository.save(githubProfileResponse.toHost());
+        return hostRepository.save(socialProfileResponse.toHost());
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/application/OAuthClient.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/application/OAuthClient.java
@@ -1,0 +1,7 @@
+package com.woowacourse.gongcheck.auth.application;
+
+import com.woowacourse.gongcheck.auth.application.response.SocialProfileResponse;
+
+public interface OAuthClient {
+    SocialProfileResponse requestSocialProfileByCode(String code);
+}

--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/application/response/OAuthAccessTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/application/response/OAuthAccessTokenResponse.java
@@ -4,15 +4,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public class GithubAccessTokenResponse {
+public class OAuthAccessTokenResponse {
 
     @JsonProperty("access_token")
     private String accessToken;
 
-    private GithubAccessTokenResponse() {
+    private OAuthAccessTokenResponse() {
     }
 
-    public GithubAccessTokenResponse(final String accessToken) {
+    public OAuthAccessTokenResponse(final String accessToken) {
         this.accessToken = accessToken;
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/application/response/SocialProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/application/response/SocialProfileResponse.java
@@ -5,7 +5,7 @@ import com.woowacourse.gongcheck.core.domain.host.Host;
 import lombok.Getter;
 
 @Getter
-public class GithubProfileResponse {
+public class SocialProfileResponse {
 
     @JsonProperty("name")
     private String nickname;
@@ -16,10 +16,10 @@ public class GithubProfileResponse {
     @JsonProperty("avatar_url")
     private String imageUrl;
 
-    private GithubProfileResponse() {
+    private SocialProfileResponse() {
     }
 
-    public GithubProfileResponse(final String nickname, final String loginName, final String githubId,
+    public SocialProfileResponse(final String nickname, final String loginName, final String githubId,
                                  final String imageUrl) {
         this.nickname = nickname;
         this.loginName = loginName;

--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/presentation/request/OAuthAccessTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/presentation/request/OAuthAccessTokenRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public class GithubAccessTokenRequest {
+public class OAuthAccessTokenRequest {
 
     private String code;
 
@@ -14,10 +14,10 @@ public class GithubAccessTokenRequest {
     @JsonProperty("client_secret")
     private String clientSecret;
 
-    private GithubAccessTokenRequest() {
+    private OAuthAccessTokenRequest() {
     }
 
-    public GithubAccessTokenRequest(final String code, final String clientId, final String clientSecret) {
+    public OAuthAccessTokenRequest(final String code, final String clientId, final String clientSecret) {
         this.code = code;
         this.clientId = clientId;
         this.clientSecret = clientSecret;

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/FakeHostAuthController.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/FakeHostAuthController.java
@@ -7,8 +7,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.gongcheck.auth.application.HostAuthService;
-import com.woowacourse.gongcheck.auth.application.response.GithubAccessTokenResponse;
-import com.woowacourse.gongcheck.auth.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.auth.application.response.OAuthAccessTokenResponse;
+import com.woowacourse.gongcheck.auth.application.response.SocialProfileResponse;
 import com.woowacourse.gongcheck.auth.application.response.TokenResponse;
 import com.woowacourse.gongcheck.auth.presentation.request.TokenRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,15 +40,15 @@ public class FakeHostAuthController {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(objectMapper.writeValueAsString(new GithubAccessTokenResponse("token"))));
+                        .body(objectMapper.writeValueAsString(new OAuthAccessTokenResponse("token"))));
 
-        GithubProfileResponse githubProfileResponse = new GithubProfileResponse("nickname", "loginName",
+        SocialProfileResponse socialProfileResponse = new SocialProfileResponse("nickname", "loginName",
                 "2", "test.com");
         mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(objectMapper.writeValueAsString(githubProfileResponse)));
+                        .body(objectMapper.writeValueAsString(socialProfileResponse)));
 
         TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
         return ResponseEntity.ok(result);
@@ -61,15 +61,15 @@ public class FakeHostAuthController {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(objectMapper.writeValueAsString(new GithubAccessTokenResponse("token"))));
+                        .body(objectMapper.writeValueAsString(new OAuthAccessTokenResponse("token"))));
 
-        GithubProfileResponse githubProfileResponse = new GithubProfileResponse("nickname", "loginName",
+        SocialProfileResponse socialProfileResponse = new SocialProfileResponse("nickname", "loginName",
                 "3", "test.com");
         mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .body(objectMapper.writeValueAsString(githubProfileResponse)));
+                        .body(objectMapper.writeValueAsString(socialProfileResponse)));
 
         TokenResponse result = hostAuthService.createToken(new TokenRequest("code"));
         return ResponseEntity.ok(result);

--- a/backend/src/test/java/com/woowacourse/gongcheck/auth/application/HostAuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/auth/application/HostAuthServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.woowacourse.gongcheck.auth.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.auth.application.response.SocialProfileResponse;
 import com.woowacourse.gongcheck.auth.application.response.TokenResponse;
 import com.woowacourse.gongcheck.auth.presentation.request.TokenRequest;
 import com.woowacourse.gongcheck.core.domain.host.HostRepository;
@@ -60,8 +60,8 @@ class HostAuthServiceTest {
 
             @BeforeEach
             void setUp() {
-                when(githubOauthClient.requestGithubProfileByCode(OAUTH_CODE))
-                        .thenReturn(new GithubProfileResponse(GITHUB_NICKNAME, GITHUB_LOGIN_NAME, GITHUB_ID,
+                when(githubOauthClient.requestSocialProfileByCode(OAUTH_CODE))
+                        .thenReturn(new SocialProfileResponse(GITHUB_NICKNAME, GITHUB_LOGIN_NAME, GITHUB_ID,
                                 GITHUB_IMAGE_URL));
                 when(jwtTokenProvider.createToken(any(), eq(HOST))).thenReturn(JWT_ACCESS_TOKEN);
                 tokenRequest = new TokenRequest(OAUTH_CODE);
@@ -86,8 +86,8 @@ class HostAuthServiceTest {
 
             @BeforeEach
             void setUp() {
-                when(githubOauthClient.requestGithubProfileByCode(OAUTH_CODE))
-                        .thenReturn(new GithubProfileResponse(GITHUB_NICKNAME, GITHUB_LOGIN_NAME, GITHUB_ID,
+                when(githubOauthClient.requestSocialProfileByCode(OAUTH_CODE))
+                        .thenReturn(new SocialProfileResponse(GITHUB_NICKNAME, GITHUB_LOGIN_NAME, GITHUB_ID,
                                 GITHUB_IMAGE_URL));
                 when(jwtTokenProvider.createToken(any(), eq(HOST))).thenReturn(JWT_ACCESS_TOKEN);
                 hostRepository.save(Host_생성("1234", Long.parseLong(GITHUB_ID)));
@@ -112,7 +112,7 @@ class HostAuthServiceTest {
 
             @BeforeEach
             void setUp() {
-                when(githubOauthClient.requestGithubProfileByCode(ERROR_OAUTH_CODE))
+                when(githubOauthClient.requestSocialProfileByCode(ERROR_OAUTH_CODE))
                         .thenThrow(UnauthorizedException.class);
                 tokenRequest = new TokenRequest(ERROR_OAUTH_CODE);
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/infrastructure/oauth/GithubOauthClientTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/infrastructure/oauth/GithubOauthClientTest.java
@@ -8,11 +8,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.gongcheck.auth.application.response.GithubAccessTokenResponse;
-import com.woowacourse.gongcheck.auth.application.response.GithubProfileResponse;
+import com.woowacourse.gongcheck.auth.application.response.OAuthAccessTokenResponse;
+import com.woowacourse.gongcheck.auth.application.response.SocialProfileResponse;
 import com.woowacourse.gongcheck.exception.InfrastructureException;
-import com.woowacourse.gongcheck.exception.NotFoundException;
-import com.woowacourse.gongcheck.exception.UnauthorizedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,7 +59,7 @@ class GithubOauthClientTest {
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> githubOauthClient.requestGithubProfileByCode("code"))
+                assertThatThrownBy(() -> githubOauthClient.requestSocialProfileByCode("code"))
                         .isInstanceOf(InfrastructureException.class)
                         .hasMessage("해당 사용자의 프로필을 요청할 수 없습니다.");
                 mockRestServiceServer.verify();
@@ -82,7 +80,7 @@ class GithubOauthClientTest {
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> githubOauthClient.requestGithubProfileByCode("code"))
+                assertThatThrownBy(() -> githubOauthClient.requestSocialProfileByCode("code"))
                         .isInstanceOf(InfrastructureException.class)
                         .hasMessage("잘못된 요청입니다.");
                 mockRestServiceServer.verify();
@@ -94,7 +92,7 @@ class GithubOauthClientTest {
 
             @BeforeEach
             void setUp() throws JsonProcessingException {
-                GithubAccessTokenResponse token = new GithubAccessTokenResponse("access_token");
+                OAuthAccessTokenResponse token = new OAuthAccessTokenResponse("access_token");
                 mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
                         .andExpect(method(HttpMethod.POST))
                         .andRespond(withStatus(HttpStatus.OK)
@@ -109,7 +107,7 @@ class GithubOauthClientTest {
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> githubOauthClient.requestGithubProfileByCode("code"))
+                assertThatThrownBy(() -> githubOauthClient.requestSocialProfileByCode("code"))
                         .isInstanceOf(InfrastructureException.class)
                         .hasMessage("해당 사용자의 프로필을 요청할 수 없습니다.");
                 mockRestServiceServer.verify();
@@ -119,32 +117,32 @@ class GithubOauthClientTest {
         @Nested
         class 권한이_있는_code로_Github에_프로필접근이_가능한_경우 {
 
-            private GithubProfileResponse githubProfileResponse;
+            private SocialProfileResponse socialProfileResponse;
 
             @BeforeEach
             void setUp() throws JsonProcessingException {
-                GithubAccessTokenResponse token = new GithubAccessTokenResponse("access_token");
+                OAuthAccessTokenResponse token = new OAuthAccessTokenResponse("access_token");
                 mockRestServiceServer.expect(requestTo("https://github.com/login/oauth/access_token"))
                         .andExpect(method(HttpMethod.POST))
                         .andRespond(withStatus(HttpStatus.OK)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .body(objectMapper.writeValueAsString(token)));
 
-                githubProfileResponse = new GithubProfileResponse("nickname", "loginName", "1", "test.com");
+                socialProfileResponse = new SocialProfileResponse("nickname", "loginName", "1", "test.com");
                 mockRestServiceServer.expect(requestTo("https://api.github.com/user"))
                         .andExpect(method(HttpMethod.GET))
                         .andRespond(withStatus(HttpStatus.OK)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .body(objectMapper.writeValueAsString(githubProfileResponse)));
+                                .body(objectMapper.writeValueAsString(socialProfileResponse)));
             }
 
             @Test
             void Github_프로필정보를_반환한다() {
-                GithubProfileResponse actual = githubOauthClient.requestGithubProfileByCode("access_token");
+                SocialProfileResponse actual = githubOauthClient.requestSocialProfileByCode("access_token");
 
                 assertThat(actual)
                         .usingRecursiveComparison()
-                        .isEqualTo(githubProfileResponse);
+                        .isEqualTo(socialProfileResponse);
                 mockRestServiceServer.verify();
             }
         }


### PR DESCRIPTION

## issue
- resolve #294 

## 코드 설명
- Github과 관련된 기술을 사용하는 부분은 infrastructure 패키지에 있는 클래스 빼고는 다 OAuth로 이름을 변경했습니다.

Github과 달리 Slack을 쓰는 부분은 종속이 심하게 되어있어서 지금 당장 변경하기는 어려울것 같아 이것 먼저 PR 합니다.
