### PR TITLE
[BE] 테스트에서 repository를 주입받고 값을 세팅하는 환경을 개선한다.

### DIFF
--- a/backend/src/test/java/com/woowacourse/gongcheck/ApplicationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/ApplicationTest.java
@@ -1,0 +1,15 @@
+package com.woowacourse.gongcheck;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@ExtendWith({DatabaseCleanerExtension.class})
+public @interface ApplicationTest {
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/DatabaseCleanerExtension.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/DatabaseCleanerExtension.java
@@ -1,0 +1,20 @@
+package com.woowacourse.gongcheck;
+
+import com.woowacourse.gongcheck.acceptance.DatabaseInitializer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements AfterEachCallback {
+
+    @Override
+    public void afterEach(final ExtensionContext context) {
+        executeDatabaseInitialize(context);
+    }
+
+    private void executeDatabaseInitialize(final ExtensionContext context) {
+        DatabaseInitializer databaseInitializer = (DatabaseInitializer) SpringExtension
+                .getApplicationContext(context).getBean("databaseInitializer");
+        databaseInitializer.truncateTables();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/SupportRepository.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/SupportRepository.java
@@ -1,0 +1,27 @@
+package com.woowacourse.gongcheck;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SupportRepository {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    public <T> T save(final T entity) {
+        entityManager.persist(entity);
+        entityManager.flush();
+        entityManager.clear();
+        return entity;
+    }
+
+    public <T> List<T> saveAll(final List<T> entities) {
+        for (T entity : entities) {
+            save(entity);
+        }
+        return entities;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/SupportRepository.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/SupportRepository.java
@@ -1,11 +1,14 @@
 package com.woowacourse.gongcheck;
 
 import java.util.List;
+import java.util.Optional;
 import javax.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
+@Transactional
 public class SupportRepository {
 
     @Autowired
@@ -22,6 +25,26 @@ public class SupportRepository {
         for (T entity : entities) {
             save(entity);
         }
+        entityManager.flush();
+        entityManager.clear();
         return entities;
+    }
+
+    public <T> Optional<T> findById(final Class<T> entityClass, final Object id) {
+        entityManager.clear();
+        return Optional.ofNullable(entityManager.find(entityClass, id));
+    }
+
+    public <T> T getById(final Class<T> entityClass, final Object id) {
+        entityManager.clear();
+        return Optional.ofNullable(entityManager.find(entityClass, id))
+                .orElseThrow(EntityNotFoundExcpetion::new);
+    }
+
+    static class EntityNotFoundExcpetion extends RuntimeException {
+
+        public EntityNotFoundExcpetion() {
+            super("Entity를 찾을 수 없습니다.");
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.auth.application.EntranceCodeProvider;
 import com.woowacourse.gongcheck.core.domain.host.Host;
-import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.presentation.request.SpacePasswordChangeRequest;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,9 +31,6 @@ class HostServiceTest {
 
     @Autowired
     private SupportRepository repository;
-
-    @Autowired
-    private HostRepository hostRepository;
 
     @Autowired
     private EntranceCodeProvider entranceCodeProvider;
@@ -62,7 +58,7 @@ class HostServiceTest {
             @Test
             void 패스워드를_수정한다() {
                 hostService.changeSpacePassword(hostId, spacePasswordChangeRequest);
-                Host actual = hostRepository.getById(hostId);
+                Host actual = repository.getById(Host.class, hostId);
 
                 assertAll(
                         () -> assertThat(actual.getSpacePassword().getValue()).isEqualTo(CHANGING_PASSWORD),

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -3,8 +3,8 @@ package com.woowacourse.gongcheck.core.application;
 import static com.woowacourse.gongcheck.fixture.FixtureFactory.Host_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.ApplicationTest;
 import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.auth.application.EntranceCodeProvider;
 import com.woowacourse.gongcheck.core.domain.host.Host;
@@ -17,11 +17,8 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
+@ApplicationTest
 @DisplayName("HostService 클래스")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class HostServiceTest {
@@ -60,11 +57,7 @@ class HostServiceTest {
                 hostService.changeSpacePassword(hostId, spacePasswordChangeRequest);
                 Host actual = repository.getById(Host.class, hostId);
 
-                assertAll(
-                        () -> assertThat(actual.getSpacePassword().getValue()).isEqualTo(CHANGING_PASSWORD),
-                        () -> assertThat(actual.getGithubId()).isEqualTo(GITHUB_ID),
-                        () -> assertThat(actual.getId()).isEqualTo(hostId)
-                );
+                assertThat(actual.getSpacePassword().getValue()).isEqualTo(CHANGING_PASSWORD);
             }
         }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.auth.application.EntranceCodeProvider;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.host.HostRepository;
@@ -30,6 +31,9 @@ class HostServiceTest {
     private HostService hostService;
 
     @Autowired
+    private SupportRepository repository;
+
+    @Autowired
     private HostRepository hostRepository;
 
     @Autowired
@@ -51,7 +55,7 @@ class HostServiceTest {
             @BeforeEach
             void setUp() {
                 spacePasswordChangeRequest = new SpacePasswordChangeRequest(CHANGING_PASSWORD);
-                hostId = hostRepository.save(Host_생성(ORIGIN_PASSWORD, GITHUB_ID))
+                hostId = repository.save(Host_생성(ORIGIN_PASSWORD, GITHUB_ID))
                         .getId();
             }
 
@@ -102,7 +106,7 @@ class HostServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1111L))
+                hostId = repository.save(Host_생성("1234", 1111L))
                         .getId();
                 expected = entranceCodeProvider.createEntranceCode(hostId);
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/JobServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/JobServiceTest.java
@@ -10,7 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.JobResponse;
+import com.woowacourse.gongcheck.core.application.response.SlackUrlResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.domain.job.Job;
@@ -48,10 +50,13 @@ import org.springframework.transaction.annotation.Transactional;
 class JobServiceTest {
 
     @Autowired
+    private JobService jobService;
+
+    @Autowired
     private EntityManager entityManager;
 
     @Autowired
-    private JobService jobService;
+    private SupportRepository repository;
 
     @Autowired
     private HostRepository hostRepository;
@@ -83,9 +88,9 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
-                List<Job> jobs = jobRepository.saveAll(
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
+                List<Job> jobs = repository.saveAll(
                         List.of(Job_생성(space, "오픈"), Job_생성(space, "청소"), Job_생성(space, "마감")));
                 jobNames = jobs.stream()
                         .map(job -> job.getName().getValue())
@@ -115,8 +120,8 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
             }
 
             @Test
@@ -136,7 +141,7 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1234L))
+                hostId = repository.save(Host_생성("1234", 1234L))
                         .getId();
             }
 
@@ -156,9 +161,9 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Host otherHost = hostRepository.save(Host_생성("1234", 2345L));
-                space = spaceRepository.save(Space_생성(otherHost, "잠실"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Host otherHost = repository.save(Host_생성("1234", 2345L));
+                space = repository.save(Space_생성(otherHost, "잠실"));
             }
 
             @Test
@@ -184,8 +189,8 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -230,8 +235,8 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -258,7 +263,7 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -284,10 +289,10 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                spaceRepository.save(Space_생성(host, "잠실"));
-                Host otherHost = hostRepository.save(Host_생성("5678", 5678L));
-                otherSpace = spaceRepository.save(Space_생성(otherHost, "잠실"));
+                host = repository.save(Host_생성("1234", 1234L));
+                repository.save(Space_생성(host, "잠실"));
+                Host otherHost = repository.save(Host_생성("5678", 5678L));
+                otherSpace = repository.save(Space_생성(otherHost, "잠실"));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -322,11 +327,11 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                originJob = jobRepository.save(Job_생성(space, "마감"));
-                originSection = sectionRepository.save(Section_생성(originJob, "소강의실"));
-                originTask = taskRepository.save(Task_생성(originSection, "불 끄기"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                originJob = repository.save(Job_생성(space, "마감"));
+                originSection = repository.save(Section_생성(originJob, "소강의실"));
+                originTask = repository.save(Task_생성(originSection, "불 끄기"));
 
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
@@ -378,8 +383,8 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -400,13 +405,15 @@ class JobServiceTest {
         @Nested
         class 다른_host의_job_id를_입력받은_경우 {
 
+            private Host anotherHost;
             private JobCreateRequest request;
             private long savedJobId;
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -418,7 +425,6 @@ class JobServiceTest {
 
             @Test
             void 예외가_발생한다() {
-                Host anotherHost = hostRepository.save(Host_생성("1234", 2345L));
                 assertThatThrownBy(() -> jobService.updateJob(anotherHost.getId(), savedJobId, request))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessage("존재하지 않는 작업입니다.");
@@ -435,7 +441,7 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
                 List<TaskCreateRequest> tasks = List
                         .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
                                 new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
@@ -465,9 +471,9 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
             }
 
             @Test
@@ -487,7 +493,7 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
             }
 
             @Test
@@ -506,10 +512,10 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                otherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                otherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
             }
 
             @Test
@@ -531,12 +537,12 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                section = sectionRepository.save(Section_생성(job, "대강의실"));
-                task = taskRepository.save(Task_생성(section, "책상 닦기"));
-                runningTask = runningTaskRepository.save(RunningTask_생성(task.getId(), false));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실 캠퍼스"));
+                job = repository.save(Job_생성(space, "청소"));
+                section = repository.save(Section_생성(job, "대강의실"));
+                task = repository.save(Task_생성(section, "책상 닦기"));
+                runningTask = repository.save(RunningTask_생성(task.getId(), false));
             }
 
             @Test
@@ -580,7 +586,7 @@ class JobServiceTest {
 
                 @BeforeEach
                 void setUp() {
-                    host = hostRepository.save(Host_생성("1234", 1234L));
+                    host = repository.save(Host_생성("1234", 1234L));
                 }
 
                 @Test
@@ -600,10 +606,10 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                myHost = hostRepository.save(Host_생성("1234", 1234L));
-                Host otherHost = hostRepository.save(Host_생성("1234", 2456L));
-                Space otherSpace = spaceRepository.save(Space_생성(otherHost, "잠실"));
-                otherJob = jobRepository.save(Job_생성(otherSpace, "톱오브스윙방"));
+                myHost = repository.save(Host_생성("1234", 1234L));
+                Host otherHost = repository.save(Host_생성("1234", 2456L));
+                Space otherSpace = repository.save(Space_생성(otherHost, "잠실"));
+                otherJob = repository.save(Job_생성(otherSpace, "톱오브스윙방"));
             }
 
             @Test
@@ -622,15 +628,16 @@ class JobServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "톱오브스윙방", "http://slackurl.com"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "톱오브스윙방", "http://slackurl.com"));
             }
 
             @Test
             void Slack_Url을_조회한다() {
-                assertThat(jobService.findSlackUrl(host.getId(), job.getId()).getSlackUrl()).isEqualTo(
-                        "http://slackurl.com");
+                SlackUrlResponse actual = jobService.findSlackUrl(host.getId(), job.getId());
+
+                assertThat(actual.getSlackUrl()).isEqualTo("http://slackurl.com");
             }
         }
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -10,25 +10,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.ApplicationTest;
 import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.SpaceResponse;
 import com.woowacourse.gongcheck.core.application.response.SpacesResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.job.Job;
-import com.woowacourse.gongcheck.core.domain.job.JobRepository;
 import com.woowacourse.gongcheck.core.domain.section.Section;
-import com.woowacourse.gongcheck.core.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.core.domain.space.Space;
-import com.woowacourse.gongcheck.core.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.core.domain.task.RunningTask;
-import com.woowacourse.gongcheck.core.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.core.domain.task.Task;
-import com.woowacourse.gongcheck.core.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.core.presentation.request.SpaceCreateRequest;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import java.util.List;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -36,38 +31,17 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
+@ApplicationTest
 @DisplayName("SpaceService 클래스")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SpaceServiceTest {
-
-    @Autowired
-    EntityManager entityManager;
 
     @Autowired
     private SpaceService spaceService;
 
     @Autowired
     private SupportRepository repository;
-
-    @Autowired
-    private SpaceRepository spaceRepository;
-
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    private SectionRepository sectionRepository;
-
-    @Autowired
-    private TaskRepository taskRepository;
-
-    @Autowired
-    private RunningTaskRepository runningTaskRepository;
 
     @Nested
     class findSpaces_메서드는 {
@@ -174,7 +148,7 @@ class SpaceServiceTest {
             @Test
             void Space를_생성한다() {
                 Long spaceId = spaceService.createSpace(host.getId(), request);
-                Space actual = spaceRepository.getById(spaceId);
+                Space actual = repository.getById(Space.class, spaceId);
 
                 assertAll(
                         () -> assertThat(actual.getName().getValue()).isEqualTo(SPACE_NAME),
@@ -367,14 +341,12 @@ class SpaceServiceTest {
             void 해당_Space_및_관련된_Job_Section_Task_RunningTask를_삭제한다() {
                 spaceService.removeSpace(host.getId(), space.getId());
 
-                entityManager.flush();
-                entityManager.clear();
                 assertAll(
-                        () -> assertThat(spaceRepository.findById(space.getId())).isEmpty(),
-                        () -> assertThat(jobRepository.findById(job.getId())).isEmpty(),
-                        () -> assertThat(sectionRepository.findById(section.getId())).isEmpty(),
-                        () -> assertThat(taskRepository.findById(task.getId())).isEmpty(),
-                        () -> assertThat(runningTaskRepository.findById(runningTask.getTaskId())).isEmpty()
+                        () -> assertThat(repository.findById(Space.class, space.getId())).isEmpty(),
+                        () -> assertThat(repository.findById(Job.class, job.getId())).isEmpty(),
+                        () -> assertThat(repository.findById(Section.class, section.getId())).isEmpty(),
+                        () -> assertThat(repository.findById(Task.class, task.getId())).isEmpty(),
+                        () -> assertThat(repository.findById(RunningTask.class, runningTask.getTaskId())).isEmpty()
                 );
             }
         }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -10,10 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.SpaceResponse;
 import com.woowacourse.gongcheck.core.application.response.SpacesResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
-import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.domain.job.Job;
 import com.woowacourse.gongcheck.core.domain.job.JobRepository;
 import com.woowacourse.gongcheck.core.domain.section.Section;
@@ -52,7 +52,7 @@ class SpaceServiceTest {
     private SpaceService spaceService;
 
     @Autowired
-    private HostRepository hostRepository;
+    private SupportRepository repository;
 
     @Autowired
     private SpaceRepository spaceRepository;
@@ -91,12 +91,12 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
 
                 Space space_1 = Space_생성(host, "잠실 캠퍼스");
                 Space space_2 = Space_생성(host, "선릉 캠퍼스");
                 Space space_3 = Space_생성(host, "양평같은방");
-                List<Space> spaces = spaceRepository.saveAll(List.of(space_1, space_2, space_3));
+                List<Space> spaces = repository.saveAll(List.of(space_1, space_2, space_3));
 
                 expected = SpacesResponse.from(spaces);
             }
@@ -123,8 +123,8 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실 캠퍼스"));
                 request = new SpaceCreateRequest(space.getName().getValue(), "https://image.gongcheck.shop/123sdf5");
             }
 
@@ -167,7 +167,7 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
                 request = new SpaceCreateRequest(SPACE_NAME, SPACE_IMAGE_URL);
             }
 
@@ -197,8 +197,8 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 2345L));
-                space = spaceRepository.save(Space_생성(host, SPACE_NAME));
+                host = repository.save(Host_생성("1234", 2345L));
+                space = repository.save(Space_생성(host, SPACE_NAME));
             }
 
             @Test
@@ -220,9 +220,9 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
             }
 
             @Test
@@ -242,8 +242,8 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
             }
 
             @Test
@@ -261,7 +261,7 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
             }
 
             @Test
@@ -282,8 +282,8 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, SPACE_NAME));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, SPACE_NAME));
             }
 
             @Test
@@ -310,8 +310,8 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
             }
 
             @Test
@@ -330,9 +330,9 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 4567L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 4567L));
+                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
             }
 
             @Test
@@ -355,12 +355,12 @@ class SpaceServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실 캠퍼스"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                section = sectionRepository.save(Section_생성(job, "대강의실"));
-                task = taskRepository.save(Task_생성(section, "책상 닦기"));
-                runningTask = runningTaskRepository.save(RunningTask_생성(task.getId(), false));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
+                job = repository.save(Job_생성(space, "청소"));
+                section = repository.save(Section_생성(job, "대강의실"));
+                task = repository.save(Task_생성(section, "책상 닦기"));
+                runningTask = repository.save(RunningTask_생성(task.getId(), false));
             }
 
             @Test

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.ApplicationTest;
 import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.SubmissionResponse;
 import com.woowacourse.gongcheck.core.application.response.SubmissionsResponse;
@@ -33,12 +34,9 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
+@ApplicationTest
 @DisplayName("SubmissionService 클래스")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SubmissionServiceTest {

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -11,21 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.SubmissionResponse;
 import com.woowacourse.gongcheck.core.application.response.SubmissionsResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
-import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.domain.job.Job;
-import com.woowacourse.gongcheck.core.domain.job.JobRepository;
 import com.woowacourse.gongcheck.core.domain.section.Section;
-import com.woowacourse.gongcheck.core.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.core.domain.space.Space;
-import com.woowacourse.gongcheck.core.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.core.domain.submission.Submission;
 import com.woowacourse.gongcheck.core.domain.submission.SubmissionRepository;
 import com.woowacourse.gongcheck.core.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.core.domain.task.Task;
-import com.woowacourse.gongcheck.core.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.core.presentation.request.SubmissionRequest;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
@@ -51,19 +47,7 @@ class SubmissionServiceTest {
     private SubmissionService submissionService;
 
     @Autowired
-    private HostRepository hostRepository;
-
-    @Autowired
-    private SpaceRepository spaceRepository;
-
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    private SectionRepository sectionRepository;
-
-    @Autowired
-    private TaskRepository taskRepository;
+    private SupportRepository repository;
 
     @Autowired
     private RunningTaskRepository runningTaskRepository;
@@ -106,7 +90,7 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
                 request = new SubmissionRequest("제출자");
             }
 
@@ -127,10 +111,10 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
                 request = new SubmissionRequest("제출자");
             }
 
@@ -152,9 +136,9 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
                 request = new SubmissionRequest("제출자");
             }
 
@@ -175,14 +159,14 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                Task task_1 = taskRepository.save(Task_생성(section, "책상 청소"));
-                Task task_2 = taskRepository.save(Task_생성(section, "의자 넣기"));
-                runningTaskRepository.save(RunningTask_생성(task_1.getId(), false));
-                runningTaskRepository.save(RunningTask_생성(task_2.getId(), false));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                Task task_1 = repository.save(Task_생성(section, "책상 청소"));
+                Task task_2 = repository.save(Task_생성(section, "의자 넣기"));
+                repository.save(RunningTask_생성(task_1.getId(), false));
+                repository.save(RunningTask_생성(task_2.getId(), false));
                 request = new SubmissionRequest("제출자");
             }
 
@@ -204,14 +188,14 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                Task task_1 = taskRepository.save(Task_생성(section, "책상 청소"));
-                Task task_2 = taskRepository.save(Task_생성(section, "의자 넣기"));
-                runningTaskRepository.save(RunningTask_생성(task_1.getId(), true));
-                runningTaskRepository.save(RunningTask_생성(task_2.getId(), true));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                Task task_1 = repository.save(Task_생성(section, "책상 청소"));
+                Task task_2 = repository.save(Task_생성(section, "의자 넣기"));
+                repository.save(RunningTask_생성(task_1.getId(), true));
+                repository.save(RunningTask_생성(task_2.getId(), true));
                 request = new SubmissionRequest("제출자");
             }
 
@@ -266,7 +250,7 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
+                host = repository.save(Host_생성("1234", 1234L));
                 request = PageRequest.of(0, 2);
             }
 
@@ -287,9 +271,9 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                space = repository.save(Space_생성(host, "잠실"));
                 request = PageRequest.of(0, 2);
             }
 
@@ -315,13 +299,13 @@ class SubmissionServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
+                host = repository.save(Host_생성("1234", 1234L));
+                space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
                 request = PageRequest.of(0, 2);
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_1));
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_2));
-                submissionRepository.save(Submission_생성(job, SUBMISSION_AUTHOR_2));
+                repository.saveAll(
+                        List.of(Submission_생성(job, SUBMISSION_AUTHOR_1), Submission_생성(job, SUBMISSION_AUTHOR_2),
+                                Submission_생성(job, SUBMISSION_AUTHOR_2)));
             }
 
             @Test

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.ApplicationTest;
 import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.JobActiveResponse;
 import com.woowacourse.gongcheck.core.application.response.RunningTaskResponse;
@@ -35,11 +36,8 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
+@ApplicationTest
 @DisplayName("TaskService 클래스")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class TaskServiceTest {
@@ -473,8 +471,7 @@ class TaskServiceTest {
             @Test
             void 체크상태를_True로_변경한다() {
                 taskService.flipRunningTask(host.getId(), task.getId());
-                RunningTask actual = runningTaskRepository.findByTaskId(runningTaskId)
-                        .orElseThrow(() -> new NotFoundException("runningtask를 찾을 수 없습니다."));
+                RunningTask actual = repository.getById(RunningTask.class, runningTaskId);
 
                 assertThat(actual.isChecked()).isTrue();
             }
@@ -501,8 +498,7 @@ class TaskServiceTest {
             @Test
             void 체크상태를_False로_변경한다() {
                 taskService.flipRunningTask(host.getId(), task.getId());
-                RunningTask actual = runningTaskRepository.findByTaskId(runningTaskId)
-                        .orElseThrow(() -> new NotFoundException("runningtask를 찾을 수 없습니다."));
+                RunningTask actual = repository.getById(RunningTask.class, runningTaskId);
 
                 assertThat(actual.isChecked()).isFalse();
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/TaskServiceTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.gongcheck.SupportRepository;
 import com.woowacourse.gongcheck.core.application.response.JobActiveResponse;
 import com.woowacourse.gongcheck.core.application.response.RunningTaskResponse;
 import com.woowacourse.gongcheck.core.application.response.RunningTasksWithSectionResponse;
@@ -18,21 +19,15 @@ import com.woowacourse.gongcheck.core.application.response.TaskResponse;
 import com.woowacourse.gongcheck.core.application.response.TasksResponse;
 import com.woowacourse.gongcheck.core.application.response.TasksWithSectionResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
-import com.woowacourse.gongcheck.core.domain.host.HostRepository;
 import com.woowacourse.gongcheck.core.domain.job.Job;
-import com.woowacourse.gongcheck.core.domain.job.JobRepository;
 import com.woowacourse.gongcheck.core.domain.section.Section;
-import com.woowacourse.gongcheck.core.domain.section.SectionRepository;
 import com.woowacourse.gongcheck.core.domain.space.Space;
-import com.woowacourse.gongcheck.core.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.core.domain.task.RunningTask;
 import com.woowacourse.gongcheck.core.domain.task.RunningTaskRepository;
 import com.woowacourse.gongcheck.core.domain.task.Task;
-import com.woowacourse.gongcheck.core.domain.task.TaskRepository;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import java.util.List;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -53,25 +48,10 @@ class TaskServiceTest {
     private TaskService taskService;
 
     @Autowired
-    private HostRepository hostRepository;
-
-    @Autowired
-    private SpaceRepository spaceRepository;
-
-    @Autowired
-    private JobRepository jobRepository;
-
-    @Autowired
-    private SectionRepository sectionRepository;
-
-    @Autowired
-    private TaskRepository taskRepository;
+    private SupportRepository repository;
 
     @Autowired
     private RunningTaskRepository runningTaskRepository;
-
-    @Autowired
-    private EntityManager entityManager;
 
     @Nested
     class createNewRunningTasks_메소드는 {
@@ -85,11 +65,11 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                List<Task> tasks = taskRepository.saveAll(
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                List<Task> tasks = repository.saveAll(
                         List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
                 taskIds = tasks.stream()
                         .map(Task::getId)
@@ -120,10 +100,10 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                sectionRepository.save(Section_생성(job, "트랙룸"));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                repository.save(Section_생성(job, "트랙룸"));
             }
 
             @Test
@@ -157,7 +137,7 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1234567L))
+                hostId = repository.save(Host_생성("1234", 1234567L))
                         .getId();
             }
 
@@ -177,12 +157,12 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                repository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
             }
 
             @Test
@@ -201,13 +181,13 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                List<Task> tasks = taskRepository.saveAll(
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                List<Task> tasks = repository.saveAll(
                         List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
-                runningTaskRepository.saveAll(tasks.stream()
+                repository.saveAll(tasks.stream()
                         .map(Task::getId)
                         .map(id -> RunningTask_생성(id, true))
                         .collect(toList()));
@@ -233,13 +213,13 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                List<Task> tasks = taskRepository.saveAll(List.of(
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                List<Task> tasks = repository.saveAll(List.of(
                         Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
-                runningTaskRepository.saveAll(tasks.stream()
+                repository.saveAll(tasks.stream()
                         .map(Task::getId)
                         .map(id -> RunningTask_생성(id, true))
                         .collect(toList()));
@@ -261,11 +241,11 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                repository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
             }
 
             @Test
@@ -299,7 +279,7 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1111L))
+                hostId = repository.save(Host_생성("1234", 1111L))
                         .getId();
             }
 
@@ -319,12 +299,12 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                repository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
             }
 
             @Test
@@ -349,28 +329,26 @@ class TaskServiceTest {
 
             private Host host;
             private Job job;
-            private Section section;
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, SECTION_NAME));
-                List<Task> tasks = taskRepository.saveAll(List.of(
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, SECTION_NAME));
+                List<Task> tasks = repository.saveAll(List.of(
                         Task_생성(section, TASK_NAME_1), Task_생성(section, TASK_NAME_2)));
-                runningTaskRepository.saveAll(tasks.stream()
+                repository.saveAll(tasks.stream()
                         .map(task -> RunningTask_생성(task.getId(), false))
                         .collect(toList()));
-                entityManager.flush();
-                entityManager.clear();
             }
 
             @Test
             void 정상적으로_RunningTasks를_조회한다() {
                 List<RunningTasksWithSectionResponse> actual = taskService.findRunningTasks(host.getId(), job.getId())
                         .getSections();
-                List<RunningTaskResponse> actualTasks = actual.get(TASK_INDEX).getTasks();
+                List<RunningTaskResponse> actualTasks = actual.get(TASK_INDEX)
+                        .getTasks();
 
                 assertAll(
                         () -> assertThat(actual)
@@ -407,7 +385,7 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1111L))
+                hostId = repository.save(Host_생성("1234", 1111L))
                         .getId();
             }
 
@@ -427,14 +405,14 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                List<Task> tasks = taskRepository.saveAll(List.of(
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                List<Task> tasks = repository.saveAll(List.of(
                         Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
-                runningTaskRepository.saveAll(tasks.stream()
+                repository.saveAll(tasks.stream()
                         .map(task -> RunningTask_생성(task.getId(), false))
                         .collect(toList()));
             }
@@ -455,11 +433,11 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                repository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
             }
 
             @Test
@@ -479,23 +457,26 @@ class TaskServiceTest {
 
             private Host host;
             private Task task;
-            private RunningTask runningTask;
+            private Long runningTaskId;
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                Job job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                task = taskRepository.save(Task_생성(section, "책상 청소"));
-                runningTask = runningTaskRepository.save(RunningTask_생성(task.getId(), false));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                Job job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                task = repository.save(Task_생성(section, "책상 청소"));
+                runningTaskId = repository.save(RunningTask_생성(task.getId(), false))
+                    .getTaskId();
             }
 
             @Test
             void 체크상태를_True로_변경한다() {
                 taskService.flipRunningTask(host.getId(), task.getId());
+                RunningTask actual = runningTaskRepository.findByTaskId(runningTaskId)
+                        .orElseThrow(() -> new NotFoundException("runningtask를 찾을 수 없습니다."));
 
-                assertThat(runningTask.isChecked()).isTrue();
+                assertThat(actual.isChecked()).isTrue();
             }
         }
 
@@ -504,23 +485,26 @@ class TaskServiceTest {
 
             private Host host;
             private Task task;
-            private RunningTask runningTask;
+            private Long runningTaskId;
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                Job job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                task = taskRepository.save(Task_생성(section, "책상 청소"));
-                runningTask = runningTaskRepository.save(RunningTask_생성(task.getId(), true));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                Job job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                task = repository.save(Task_생성(section, "책상 청소"));
+                runningTaskId = repository.save(RunningTask_생성(task.getId(), true))
+                    .getTaskId();
             }
 
             @Test
             void 체크상태를_False로_변경한다() {
                 taskService.flipRunningTask(host.getId(), task.getId());
+                RunningTask actual = runningTaskRepository.findByTaskId(runningTaskId)
+                        .orElseThrow(() -> new NotFoundException("runningtask를 찾을 수 없습니다."));
 
-                assertThat(runningTask.isChecked()).isFalse();
+                assertThat(actual.isChecked()).isFalse();
             }
         }
 
@@ -547,7 +531,7 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1111L))
+                hostId = repository.save(Host_생성("1234", 1111L))
                         .getId();
             }
 
@@ -567,12 +551,12 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                Job job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskId = taskRepository.save(Task_생성(section, "책상 청소"))
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                Job job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                taskId = repository.save(Task_생성(section, "책상 청소"))
                         .getId();
             }
 
@@ -592,11 +576,11 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                Job job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskId = taskRepository.save(Task_생성(section, "책상 청소"))
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                Job job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                taskId = repository.save(Task_생성(section, "책상 청소"))
                         .getId();
             }
 
@@ -624,11 +608,11 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                host = hostRepository.save(Host_생성("1234", 1234L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, SECTION_NAME));
-                taskRepository.saveAll(List.of(Task_생성(section, TASK_NAME_1), Task_생성(section, TASK_NAME_2)));
+                host = repository.save(Host_생성("1234", 1234L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, SECTION_NAME));
+                repository.saveAll(List.of(Task_생성(section, TASK_NAME_1), Task_생성(section, TASK_NAME_2)));
             }
 
             @Test
@@ -669,7 +653,7 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                hostId = hostRepository.save(Host_생성("1234", 1111L))
+                hostId = repository.save(Host_생성("1234", 1111L))
                         .getId();
             }
 
@@ -689,12 +673,12 @@ class TaskServiceTest {
 
             @BeforeEach
             void setUp() {
-                Host host = hostRepository.save(Host_생성("1234", 1234L));
-                anotherHost = hostRepository.save(Host_생성("1234", 2345L));
-                Space space = spaceRepository.save(Space_생성(host, "잠실"));
-                job = jobRepository.save(Job_생성(space, "청소"));
-                Section section = sectionRepository.save(Section_생성(job, "트랙룸"));
-                taskRepository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
+                Host host = repository.save(Host_생성("1234", 1234L));
+                anotherHost = repository.save(Host_생성("1234", 2345L));
+                Space space = repository.save(Space_생성(host, "잠실"));
+                job = repository.save(Job_생성(space, "청소"));
+                Section section = repository.save(Section_생성(job, "트랙룸"));
+                repository.saveAll(List.of(Task_생성(section, "책상 청소"), Task_생성(section, "의자 넣기")));
             }
 
             @Test


### PR DESCRIPTION
## issue
- resolve #322

## 코드 설명
### 공통 기능 분리
- repository를 항상 주입받는 것을 막기 위해 `SupportRespository`를 추가하였습니다.
    - `save()`, `saveAll()`을 통해 저장 기능을 사용할 수 있습니다.
    - `findById()`, `getById()`를 통해 id를 통한 검색 기능을 사용할 수 있습니다.
### setup 시 영속성 컨텍스트 비움
- repository를 setup에서 사용할 때 entitymanager에 영속성 컨텍스트가 남아있는 것을 제거하였습니다.
    - 테스트 진행 시 영속성 컨텍스트가 남아 온전히 Service만의 테스트가 진행되지 않으므로 flush, clear를 통해 독립성을 조금 더 유지할 수 있도록 변경하였습니다. 
### @ApplicationTest
- Application의 테스트 진행 시 실제로 commit되는 것까지가 `@Service`의 역할이라고 판단, 해당 부분까지 테스트 진행할 수 있도록 변경점을 잡았습니다.
- 기존의 `@SpringBootTest`와 `@Transactional`조합으로는 commit이 날아가지 않으므로 온전히 한 트랜잭션의 모든 내용을 테스트하지 못한다고 판단하였습니다.
- 따라서 `DatabaseInitializer`를 매 테스트마다 진행시켜주는 `@ApplicationTest`를 추가하고 변환하였습니다.



### 주의사항
테스트 코드의 길이가 길아 load dif를 해야 전체 파일이 보이는 코드가 있으니 확인하여 리뷰부탁드립니다

<img width="337" alt="스크린샷 2022-08-08 오후 7 05 44" src="https://user-images.githubusercontent.com/69106910/183393897-637aa9d8-0c8f-4779-ae78-407f6c0e7406.png">
