### PR TITLE
[BE] RestDocs request-fields.adoc에 nullable, length 필드를 추가한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/auth/presentation/request/GuestEnterRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/auth/presentation/request/GuestEnterRequest.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 public class GuestEnterRequest {
 
-
     @NotNull
     private String password;
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
@@ -48,7 +48,7 @@ class GuestAuthDocumentation extends DocumentationTest {
                                     parameterWithName("entranceCode").description("호스트가 제공하는 입장코드")),
                             requestFields(
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("공간 비밀번호")
-                                            .attributes(key("length").value(4))),
+                                            .attributes(key("length").value(4)).optional()),
                             responseFields(
                                     fieldWithPath("token").type(JsonFieldType.STRING)
                                             .description("Access Token")

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.auth.application.response.GuestTokenResponse;
 import com.woowacourse.gongcheck.auth.presentation.request.GuestEnterRequest;
@@ -46,9 +47,11 @@ class GuestAuthDocumentation extends DocumentationTest {
                             pathParameters(
                                     parameterWithName("entranceCode").description("호스트가 제공하는 입장코드")),
                             requestFields(
-                                    fieldWithPath("password").type(JsonFieldType.STRING).description("공간 비밀번호")),
+                                    fieldWithPath("password").type(JsonFieldType.STRING).description("공간 비밀번호")
+                                            .attributes(key("length").value(4))),
                             responseFields(
-                                    fieldWithPath("token").type(JsonFieldType.STRING).description("Access Token")
+                                    fieldWithPath("token").type(JsonFieldType.STRING)
+                                            .description("Access Token")
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/GuestAuthDocumentation.java
@@ -48,7 +48,8 @@ class GuestAuthDocumentation extends DocumentationTest {
                                     parameterWithName("entranceCode").description("호스트가 제공하는 입장코드")),
                             requestFields(
                                     fieldWithPath("password").type(JsonFieldType.STRING).description("공간 비밀번호")
-                                            .attributes(key("length").value(4)).optional()),
+                                            .attributes(key("length").value(4))
+                                            .attributes(key("nullable").value(true))),
                             responseFields(
                                     fieldWithPath("token").type(JsonFieldType.STRING)
                                             .description("Access Token")

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
@@ -33,7 +33,8 @@ public class HostAuthDocumentation extends DocumentationTest {
                     .then().log().all()
                     .apply(document("hosts/auth/success",
                             requestFields(
-                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")),
+                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")
+                                            .optional()),
                             responseFields(
                                     fieldWithPath("token").type(JsonFieldType.STRING).description("Access Token"),
                                     fieldWithPath("alreadyJoin").type(JsonFieldType.BOOLEAN).description("가입 여부")

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.auth.application.response.TokenResponse;
 import com.woowacourse.gongcheck.auth.presentation.request.TokenRequest;
@@ -33,7 +34,8 @@ public class HostAuthDocumentation extends DocumentationTest {
                     .then().log().all()
                     .apply(document("hosts/auth/success",
                             requestFields(
-                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")),
+                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")
+                                            .attributes(key("nullable").value(true))),
                             responseFields(
                                     fieldWithPath("token").type(JsonFieldType.STRING).description("Access Token"),
                                     fieldWithPath("alreadyJoin").type(JsonFieldType.BOOLEAN).description("가입 여부")

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostAuthDocumentation.java
@@ -33,8 +33,7 @@ public class HostAuthDocumentation extends DocumentationTest {
                     .then().log().all()
                     .apply(document("hosts/auth/success",
                             requestFields(
-                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")
-                                            .optional()),
+                                    fieldWithPath("code").type(JsonFieldType.STRING).description("Authorization Code")),
                             responseFields(
                                     fieldWithPath("token").type(JsonFieldType.STRING).description("Access Token"),
                                     fieldWithPath("alreadyJoin").type(JsonFieldType.BOOLEAN).description("가입 여부")

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/ImageUploadDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/ImageUploadDocumentation.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.core.application.response.ImageUrlResponse;
 import java.io.File;
@@ -37,7 +38,8 @@ class ImageUploadDocumentation extends DocumentationTest {
                 .then().log().all()
                 .apply(document("image-upload",
                         requestParts(partWithName("image")
-                                .description("The version of the image").optional()),
+                                .description("The version of the image")
+                                .attributes(key("nullable").value(true))),
                         responseFields(
                                 fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("저장된 Image Url")
                         )

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/ImageUploadDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/ImageUploadDocumentation.java
@@ -37,7 +37,7 @@ class ImageUploadDocumentation extends DocumentationTest {
                 .then().log().all()
                 .apply(document("image-upload",
                         requestParts(partWithName("image")
-                                .description("The version of the image")),
+                                .description("The version of the image").optional()),
                         responseFields(
                                 fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("저장된 Image Url")
                         )

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -16,6 +16,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.core.application.response.JobsResponse;
 import com.woowacourse.gongcheck.core.application.response.SlackUrlResponse;
@@ -99,19 +100,20 @@ class JobDocumentation extends DocumentationTest {
                             pathParameters(
                                     parameterWithName("spaceId").description("Job을 생성할 Space Id")),
                             requestFields(
-                                    fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름"),
+                                    fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름"),
+                                            .description("Section 이름").attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명"),
+                                            .description("Section 설명").optional().attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url"),
+                                            .description("Section Image Url").optional(),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름"),
+                                            .description("Task 이름").attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명"),
+                                            .description("Task 설명").optional().attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Task Image Url")
+                                            .description("Task Image Url").optional()
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -225,19 +227,20 @@ class JobDocumentation extends DocumentationTest {
                             pathParameters(
                                     parameterWithName("jobId").description("수정할 Job Id")),
                             requestFields(
-                                    fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름"),
+                                    fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름"),
+                                            .description("Section 이름").attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명"),
+                                            .description("Section 설명").optional().attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url"),
+                                            .description("Section Image Url").optional(),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름"),
+                                            .description("Task 이름").attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명"),
+                                            .description("Task 설명").optional().attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Task Image Url")
+                                            .description("Task Image Url").optional()
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());
@@ -375,9 +378,11 @@ class JobDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("Slack Url을 수정할 Job Id")),
                             requestFields(
                                     fieldWithPath("slackUrl").type(JsonFieldType.STRING).description("수정할 Slack Url")
+                                            .optional()
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());
+
         }
 
         @Test

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -100,20 +100,29 @@ class JobDocumentation extends DocumentationTest {
                             pathParameters(
                                     parameterWithName("spaceId").description("Job을 생성할 Space Id")),
                             requestFields(
-                                    fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
-                                            .attributes(key("length").value(10)).optional(),
+                                    fieldWithPath("name").type(JsonFieldType.STRING)
+                                            .description("Job 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Section 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명").attributes(key("length").value(128)),
+                                            .description("Section 설명")
+                                            .attributes(key("length").value(128))
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url"),
+                                            .description("Section Image Url")
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Task 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명").attributes(key("length").value(128)),
+                                            .description("Task 설명")
+                                            .attributes(key("length").value(128))
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
                                             .description("Task Image Url")
+                                            .attributes(key("nullable").value(true))
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -228,19 +237,27 @@ class JobDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("수정할 Job Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
-                                            .attributes(key("length").value(10)).optional(),
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Section 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명").attributes(key("length").value(128)),
+                                            .description("Section 설명")
+                                            .attributes(key("length").value(128))
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url"),
+                                            .description("Section Image Url")
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Task 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명").attributes(key("length").value(128)),
+                                            .description("Task 설명")
+                                            .attributes(key("length").value(128))
+                                            .attributes(key("nullable").value(true)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
                                             .description("Task Image Url")
+                                            .attributes(key("nullable").value(true))
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());
@@ -377,7 +394,9 @@ class JobDocumentation extends DocumentationTest {
                             pathParameters(
                                     parameterWithName("jobId").description("Slack Url을 수정할 Job Id")),
                             requestFields(
-                                    fieldWithPath("slackUrl").type(JsonFieldType.STRING).description("수정할 Slack Url")
+                                    fieldWithPath("slackUrl").type(JsonFieldType.STRING)
+                                            .description("수정할 Slack Url")
+                                            .attributes(key("nullable").value(true))
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/JobDocumentation.java
@@ -101,19 +101,19 @@ class JobDocumentation extends DocumentationTest {
                                     parameterWithName("spaceId").description("Job을 생성할 Space Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
-                                            .attributes(key("length").value(10)),
+                                            .attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름").attributes(key("length").value(10)),
+                                            .description("Section 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명").optional().attributes(key("length").value(128)),
+                                            .description("Section 설명").attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url").optional(),
+                                            .description("Section Image Url"),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름").attributes(key("length").value(10)),
+                                            .description("Task 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명").optional().attributes(key("length").value(128)),
+                                            .description("Task 설명").attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Task Image Url").optional()
+                                            .description("Task Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -228,19 +228,19 @@ class JobDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("수정할 Job Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING).description("Job 이름")
-                                            .attributes(key("length").value(10)),
+                                            .attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].name").type(JsonFieldType.STRING)
-                                            .description("Section 이름").attributes(key("length").value(10)),
+                                            .description("Section 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].description").type(JsonFieldType.STRING)
-                                            .description("Section 설명").optional().attributes(key("length").value(128)),
+                                            .description("Section 설명").attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Section Image Url").optional(),
+                                            .description("Section Image Url"),
                                     fieldWithPath("sections.[].tasks.[].name").type(JsonFieldType.STRING)
-                                            .description("Task 이름").attributes(key("length").value(10)),
+                                            .description("Task 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("sections.[].tasks.[].description").type(JsonFieldType.STRING)
-                                            .description("Task 설명").optional().attributes(key("length").value(128)),
+                                            .description("Task 설명").attributes(key("length").value(128)),
                                     fieldWithPath("sections.[].tasks.[].imageUrl").type(JsonFieldType.STRING)
-                                            .description("Task Image Url").optional()
+                                            .description("Task Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());
@@ -378,7 +378,6 @@ class JobDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("Slack Url을 수정할 Job Id")),
                             requestFields(
                                     fieldWithPath("slackUrl").type(JsonFieldType.STRING).description("수정할 Slack Url")
-                                            .optional()
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.core.application.response.SpaceResponse;
 import com.woowacourse.gongcheck.core.application.response.SpacesResponse;
@@ -80,9 +81,9 @@ class SpaceDocumentation extends DocumentationTest {
                     .apply(document("spaces/create/success",
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름"),
+                                            .description("Space 이름").attributes(key("length").value(10)),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                            .description("Space Image Url")
+                                            .description("Space Image Url").optional()
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -174,9 +175,9 @@ class SpaceDocumentation extends DocumentationTest {
                                     parameterWithName("spaceId").description("수정할 Space Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름"),
+                                            .description("Space 이름").attributes(key("length").value(10)),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                            .description("Space Image Url")
+                                            .description("Space Image Url").optional()
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -81,9 +81,11 @@ class SpaceDocumentation extends DocumentationTest {
                     .apply(document("spaces/create/success",
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Space 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
                                             .description("Space Image Url")
+                                            .attributes(key("nullable").value(true))
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -175,9 +177,11 @@ class SpaceDocumentation extends DocumentationTest {
                                     parameterWithName("spaceId").description("수정할 Space Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름").attributes(key("length").value(10)).optional(),
+                                            .description("Space 이름")
+                                            .attributes(key("length").value(10)),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
                                             .description("Space Image Url")
+                                            .attributes(key("nullable").value(true))
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SpaceDocumentation.java
@@ -81,9 +81,9 @@ class SpaceDocumentation extends DocumentationTest {
                     .apply(document("spaces/create/success",
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름").attributes(key("length").value(10)),
+                                            .description("Space 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                            .description("Space Image Url").optional()
+                                            .description("Space Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.CREATED.value());
@@ -175,9 +175,9 @@ class SpaceDocumentation extends DocumentationTest {
                                     parameterWithName("spaceId").description("수정할 Space Id")),
                             requestFields(
                                     fieldWithPath("name").type(JsonFieldType.STRING)
-                                            .description("Space 이름").attributes(key("length").value(10)),
+                                            .description("Space 이름").attributes(key("length").value(10)).optional(),
                                     fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                            .description("Space Image Url").optional()
+                                            .description("Space Image Url")
                             )
                     ))
                     .statusCode(HttpStatus.NO_CONTENT.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
@@ -65,7 +65,8 @@ class SubmissionDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("Submission을 제출할 Job Id")),
                             requestFields(
                                     fieldWithPath("author").type(JsonFieldType.STRING)
-                                            .description("제출자").attributes(key("length").value(10)).optional()
+                                            .description("제출자")
+                                            .attributes(key("length").value(10))
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
@@ -18,6 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.woowacourse.gongcheck.core.application.response.SubmissionCreatedResponse;
 import com.woowacourse.gongcheck.core.application.response.SubmissionsResponse;
@@ -64,7 +65,7 @@ class SubmissionDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("Submission을 제출할 Job Id")),
                             requestFields(
                                     fieldWithPath("author").type(JsonFieldType.STRING)
-                                            .description("제출자")
+                                            .description("제출자").attributes(key("length").value(10))
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/SubmissionDocumentation.java
@@ -65,7 +65,7 @@ class SubmissionDocumentation extends DocumentationTest {
                                     parameterWithName("jobId").description("Submission을 제출할 Job Id")),
                             requestFields(
                                     fieldWithPath("author").type(JsonFieldType.STRING)
-                                            .description("제출자").attributes(key("length").value(10))
+                                            .description("제출자").attributes(key("length").value(10)).optional()
                             )
                     ))
                     .statusCode(HttpStatus.OK.value());

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -4,7 +4,7 @@
 {{#fields}}
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#nullable}}true{{/nullable}}{{/tableCellContent}}
 |{{#tableCellContent}}{{#length}}{{length}}{{/length}}{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,13 @@
+|===
+|Path|Type|Nullable|Length|Description
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#length}}{{length}}{{/length}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
## issue
- resolve #366

## 코드 설명
- 기본적으로 request-fields.adoc의 default 필드는 path, type, description 입니다.
- 여기서 추가적으로 custom field를 추가하고 싶다면 src/test/resources/org/springframework/restdocs/template 아래에 request-fields.snippet 파일을 만들어 추가적인 필드를 명시해줘야 합니다.

```
request-fields.snippet

|===
|Path|Type|Nullable|Length|Description

{{#fields}}
|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
|{{#tableCellContent}}{{#nullable}}true{{/nullable}}{{/tableCellContent}} --- (1)
|{{#tableCellContent}}{{#length}}{{length}}{{/length}}{{/tableCellContent}} --- (2)
|{{#tableCellContent}}{{description}}{{/tableCellContent}}

{{/fields}}

|===
```
request-fields.snippet에 있는 모든 필드는 기본적으로 모두 명시해줘야 테스트시 에러가 발생하지 않습니다.
하지만 nullable이나 length 필드의 경우 명시하지 않아도 되는 상황이 존재합니다.
따라서 (1) - nullable field를 명시 해줬을 경우에만 값이 추가되게 설정했습니다. 
또한 (2) - length field는 명시 해줬을 경우에만 값이 추가되게 설정했습니다.

결과 입니다.
<img width="885" alt="image" src="https://user-images.githubusercontent.com/55445564/183539393-0f4dc1c3-8353-4f53-b4ff-d3da7a147b3d.png">


