### PR TITLE
[FE] 유저페이지 토큰의 공간과 접속 공간이 다를 경우 접속할 수 없도록 한다.

### DIFF
--- a/frontend/src/layouts/UserLayout/index.tsx
+++ b/frontend/src/layouts/UserLayout/index.tsx
@@ -2,7 +2,10 @@ import ErrorUserTask from '@/ErrorBoundary/ErrorUserTask';
 import ErrorUserToken from '@/ErrorBoundary/ErrorUserToken';
 import { Global } from '@emotion/react';
 import { Suspense, useEffect } from 'react';
+import { useQuery } from 'react-query';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
+
+import apiHost from '@/apis/host';
 
 import { ID } from '@/types';
 
@@ -15,8 +18,10 @@ const UserLayout: React.FC = () => {
 
   const { hostId } = useParams() as { hostId: ID };
 
+  const { data: entranceCodeData } = useQuery(['hostId', hostId], apiHost.getEntranceCode);
+
   useEffect(() => {
-    if (!localStorage.getItem('token')) {
+    if (!localStorage.getItem('token') || entranceCodeData?.entranceCode !== hostId) {
       navigate(`/enter/${hostId}/pwd`);
     }
   }, []);


### PR DESCRIPTION
## issue
- resolve #463 

## 코드 설명
- UserLayout에서 입장 코드를 받아와 params에 있는 입장 코드와 비교한다.
- 입장 코드가 서로 다를 경우 비밀번호 입력페이지로 이동한다.
