### PR TITLE
[BE] 인수테스트에 cucumber를 적용하기 위한 환경을 설정한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -13,6 +13,7 @@ sourceCompatibility = '11'
 
 configurations {
     asciidoctorExtensions
+    cucumberRuntime.extendsFrom(implementation, testImplementation, runtimeOnly)
 }
 
 repositories {
@@ -57,6 +58,11 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+
+    //cucumber
+    testImplementation 'io.cucumber:cucumber-java:6.10.4'
+    testImplementation 'io.cucumber:cucumber-spring:6.10.4'
+    testImplementation 'io.cucumber:cucumber-junit-platform-engine:6.10.4'
 
     // slack
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
@@ -117,6 +123,25 @@ jacocoTestReport {
         html.enabled true
         xml.enabled true
     }
+}
+
+task cucumber() {
+    dependsOn assemble, compileTestJava
+    doLast {
+        javaexec {
+            main = "io.cucumber.core.cli.Main"
+            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
+            args = [
+                    '--plugin', 'pretty',
+                    '--plugin', 'html:build/reports/cucumber/cucumber-report.html',
+                    '--glue', 'com.woowacourse.gongcheck',
+                    'src/test/resources/features']
+        }
+    }
+}
+
+check {
+    dependsOn(cucumber)
 }
 
 sonarqube {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -140,8 +140,8 @@ task cucumber() {
     }
 }
 
-check {
-    dependsOn(cucumber)
+build {
+    dependsOn cucumber
 }
 
 sonarqube {

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
@@ -1,0 +1,38 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(scopeName = "cucumber-glue")
+public class AcceptanceContext {
+
+    public RequestSpecification request;
+    public Response response;
+    public Map<String, Object> storage;
+
+    public AcceptanceContext() {
+        reset();
+    }
+
+    private void reset() {
+        request = null;
+        response = null;
+        storage = new HashMap<>();
+    }
+
+    public void invokeHttpPost(String path, Object data) {
+        request = RestAssured
+                .given().log().all()
+                .body(data).contentType(ContentType.JSON);
+        response = request.post(path);
+        response.then().log().all();
+    }
+}
+

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceContext.java
@@ -30,9 +30,9 @@ public class AcceptanceContext {
     public void invokeHttpPost(String path, Object data) {
         request = RestAssured
                 .given().log().all()
-                .body(data).contentType(ContentType.JSON);
+                .body(data)
+                .contentType(ContentType.JSON);
         response = request.post(path);
         response.then().log().all();
     }
 }
-

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceSteps.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceSteps.java
@@ -1,0 +1,14 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import com.woowacourse.gongcheck.auth.application.EntranceCodeProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AcceptanceSteps {
+
+    @Autowired
+    public AcceptanceContext context;
+
+    @Autowired
+    public EntranceCodeProvider entranceCodeProvider;
+}
+

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceSteps.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/AcceptanceSteps.java
@@ -11,4 +11,3 @@ public class AcceptanceSteps {
     @Autowired
     public EntranceCodeProvider entranceCodeProvider;
 }
-

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberIntegrationTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/CucumberIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.woowacourse.gongcheck.cucumber;
+
+import com.woowacourse.gongcheck.acceptance.DatabaseInitializer;
+import io.cucumber.java.Before;
+import io.cucumber.spring.CucumberContextConfiguration;
+import io.restassured.RestAssured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@CucumberContextConfiguration
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("test")
+public class CucumberIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private DatabaseInitializer databaseInitializer;
+
+    @Before("@api")
+    public void setupForApi() {
+        RestAssured.port = port;
+        databaseInitializer.initTable();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/gongcheck/cucumber/steps/GuestAuthStepDefinitions.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/cucumber/steps/GuestAuthStepDefinitions.java
@@ -1,0 +1,31 @@
+package com.woowacourse.gongcheck.cucumber.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.gongcheck.auth.application.response.GuestTokenResponse;
+import com.woowacourse.gongcheck.auth.presentation.request.GuestEnterRequest;
+import com.woowacourse.gongcheck.cucumber.AcceptanceSteps;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.http.HttpStatus;
+
+public class GuestAuthStepDefinitions extends AcceptanceSteps {
+
+    @When("Space의 패스워드를 입력하면")
+    public void Space의_패스워드를_입력하면() {
+        GuestEnterRequest guestEnterRequest = new GuestEnterRequest("1234");
+        String entranceCode = entranceCodeProvider.createEntranceCode(1L);
+
+        context.invokeHttpPost("/api/hosts/" + entranceCode + "/enter/", guestEnterRequest);
+    }
+
+    @Then("엑세스 토큰을 받는다")
+    public void 엑세스_토큰을_받는다() {
+        assertAll(
+                () -> assertThat(context.response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(
+                        context.response.body().jsonPath().getObject(".", GuestTokenResponse.class)).isNotNull()
+        );
+    }
+}

--- a/backend/src/test/resources/features/guestAuth.feature
+++ b/backend/src/test/resources/features/guestAuth.feature
@@ -1,0 +1,7 @@
+@api
+Feature: Space 입장 기능
+
+  Scenario: Space 입장하기
+    When Space의 패스워드를 입력하면
+    Then 엑세스 토큰을 받는다
+


### PR DESCRIPTION
## issue
- resolve #184 

## 코드 설명

기본적인 환경 설정과 시나리오 코드 예시 하나를 추가했습니다.


### 이전에 cucumber task가 동작하지 않았던 이유.

저번에 함께 트러블슈팅을 할 때, H2 드라이버를 찾아올 수 없다는 에러가 발생했었는데요, 알고보니 큐컴버를 위한 클래스패스 설정에서 `runtimeOnly` 의존성이 설정이 안되어 있어서 그랬습니다.

아래와 같이 런타임 의존성도 패스에 추가하여 문제를 해결했습니다.

```groovy
configurations {
    cucumberRuntime.extendsFrom(implementation, testImplementation, runtimeOnly)
}

...
task acceptanceTest() {
    dependsOn assemble, compileTestJava
    doLast {
        javaexec {
            main = "io.cucumber.core.cli.Main"
            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
            args = [
                    '--plugin', 'pretty',
                    '--plugin', 'html:build/reports/cucumber/cucumber-report.html',
                    '--glue', 'com.woowacourse.gongcheck',
                    'src/test/resources/features']
        }
    }
}
```

### 빌드시 큐컴버 태스크가 돌아가지 않는 문제.

gradle에 `check`라는 task가 있습니다. 여기 해당 태스크를 추가하면 빌드할 때 함께 돌아갑니다. `build`는 `check`에 의존하고 있습니다.

관련 문서: https://docs.gradle.org/current/userguide/base_plugin.html#sec:base_tasks

### 기본 설정

`CucumberIntegrationTest`: 인수테스트를 할 때, 스프링 설정과 큐컴버 설정을 읽어오는 부트스트랩 클래스입니다.

`AcceptanceContext`: 큐컴버로 테스트를 작성할 때, Given, When, Then을 각각 다른 메서드로 정의합니다. 이때 다른 메서드에서 상태(ex. `io.restassured.response.Response`)를 공유할 수 있도록 전역적으로 상태를 관리하는 객체가 하나 필요합니다. 매 시나리오마다 새로 생성됩니다.

`AcceptanceStep`: StepDefinition을 작성할 때는 이 클래스를 상속받아 context를 통해 요청을 보내고 응답을 꺼내오면 됩니다.


## 개선사항

현재 `CucumberIntegrationTest`에 `@ActiveProfiles("test")`를 붙이지 않으면 빌드할 때 local 설정을 읽어오는 문제가 있습니다. 차후 원인을 찾아보고 수정하도록 하겠습니다. 일단 `@ActiveProfiles("test")`를 붙이면 빌드할 때 test 설정을 읽어옵니다.

현재 존재하는 AcceptanceTest 코드를 모두 Cucumber로 마이그레이션 하면 `CucumberIntegrationTest` -> `AcceptanceTest`로 이름을 수정하도록 하겠습니다.
