### PR TITLE
[FE] 작업 체크 페이지에 이미지 LazyLoading을 적용한다.

### DIFF
--- a/frontend/src/components/user/SectionInfoPreview/index.tsx
+++ b/frontend/src/components/user/SectionInfoPreview/index.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
 import { FaMapMarkedAlt } from 'react-icons/fa';
+
+import useLazyImage from '@/hooks/useLazyImage';
 
 import styles from './styles';
 
@@ -7,31 +8,6 @@ interface SectionInfoPreviewProps {
   imageUrl: string;
   onClick: () => void;
 }
-
-const useLazyImage = () => {
-  const lazyImageRef = useRef<HTMLImageElement>(null);
-  const observerRef = useRef<IntersectionObserver>();
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const intersectionCallBack = (entries: IntersectionObserverEntry[], io: IntersectionObserver) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        io.unobserve(entry.target);
-        setIsLoaded(true);
-      }
-    });
-  };
-
-  useEffect(() => {
-    if (!observerRef.current) {
-      observerRef.current = new IntersectionObserver(intersectionCallBack);
-    }
-
-    lazyImageRef.current && observerRef.current.observe(lazyImageRef.current);
-  }, []);
-
-  return { isLoaded, lazyImageRef };
-};
 
 const SectionInfoPreview: React.FC<SectionInfoPreviewProps> = ({ imageUrl, onClick }) => {
   const { isLoaded, lazyImageRef } = useLazyImage();

--- a/frontend/src/components/user/SectionInfoPreview/index.tsx
+++ b/frontend/src/components/user/SectionInfoPreview/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { FaMapMarkedAlt } from 'react-icons/fa';
 
 import styles from './styles';
@@ -7,11 +8,38 @@ interface SectionInfoPreviewProps {
   onClick: () => void;
 }
 
+const useLazyImage = () => {
+  const lazyImageRef = useRef<HTMLImageElement>(null);
+  const observerRef = useRef<IntersectionObserver>();
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const intersectionCallBack = (entries: IntersectionObserverEntry[], io: IntersectionObserver) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        io.unobserve(entry.target);
+        setIsLoaded(true);
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver(intersectionCallBack);
+    }
+
+    lazyImageRef.current && observerRef.current.observe(lazyImageRef.current);
+  }, []);
+
+  return { isLoaded, lazyImageRef };
+};
+
 const SectionInfoPreview: React.FC<SectionInfoPreviewProps> = ({ imageUrl, onClick }) => {
+  const { isLoaded, lazyImageRef } = useLazyImage();
+
   return (
     <div css={styles.wrapper} onClick={onClick}>
       <div css={styles.imageWrapper}>
-        <img css={styles.image} src={imageUrl} />
+        <img css={styles.image} src={isLoaded ? imageUrl : ''} ref={lazyImageRef} />
       </div>
       <FaMapMarkedAlt css={styles.icon} size={24} />
     </div>

--- a/frontend/src/hooks/useLazyImage.ts
+++ b/frontend/src/hooks/useLazyImage.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useLazyImage = () => {
+  const lazyImageRef = useRef<HTMLImageElement>(null);
+  const observerRef = useRef<IntersectionObserver>();
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const intersectionCallBack = (entries: IntersectionObserverEntry[], io: IntersectionObserver) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        io.unobserve(entry.target);
+        setIsLoaded(true);
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver(intersectionCallBack);
+    }
+
+    lazyImageRef.current && observerRef.current.observe(lazyImageRef.current);
+  }, []);
+
+  return { isLoaded, lazyImageRef };
+};
+
+export default useLazyImage;


### PR DESCRIPTION
## issue
- resolve #470 

## 코드 설명
- IntersectionObserver를 통해 이미지가 스크롤에 들어왔을때 로딩하는 useLazyImage 훅을 통해 이미지 LazyLoading 을 적용
