### PR TITLE
[FE] 링크 복사 방식 변경

### DIFF
--- a/frontend/src/pages/host/DashBoard/useDashBoard.tsx
+++ b/frontend/src/pages/host/DashBoard/useDashBoard.tsx
@@ -1,4 +1,3 @@
-import { clip } from '@/utils/copy';
 import { useQuery } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -31,7 +30,7 @@ const useDashBoard = () => {
   const { refetch: copyEntranceLink } = useQuery(['entranceCode'], () => apiHost.getEntranceCode(), {
     enabled: false,
     onSuccess: data => {
-      clip(`${location.origin}/enter/${data.entranceCode}/pwd`);
+      navigator.clipboard.writeText(`${location.origin}/enter/${data.entranceCode}/pwd`);
       openToast('SUCCESS', '공간 입장 링크가 복사되었습니다.');
     },
     onError: () => {

--- a/frontend/src/utils/copy.ts
+++ b/frontend/src/utils/copy.ts
@@ -1,8 +1,0 @@
-export const clip = (url: string): void => {
-  const textarea = document.createElement('textarea');
-  document.body.appendChild(textarea);
-  textarea.value = url;
-  textarea.select();
-  document.execCommand('copy');
-  document.body.removeChild(textarea);
-};


### PR DESCRIPTION
## issue
- resolve #515 

## 코드 설명
- HTTPS 에서 copy가 안되어서 deprecated 된 Wep API(document.execCommand('copy'))를 사용했는데, 
배포환경이 HTTPS로 변경되어서 navigator.clipboard.writeText 방식으로 변경한다.
- 문제상황은 issue에 적혀있음
