### PR TITLE
[BE] HostServiceTest와 SpaceServiceTest를 개선한다

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/core/application/SpaceService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/application/SpaceService.java
@@ -46,6 +46,12 @@ public class SpaceService {
         this.runningTaskRepository = runningTaskRepository;
     }
 
+    public SpaceResponse findSpace(final Long hostId, final Long spaceId) {
+        Host host = hostRepository.getById(hostId);
+        Space space = spaceRepository.getByHostAndId(host, spaceId);
+        return SpaceResponse.from(space);
+    }
+
     public SpacesResponse findSpaces(final Long hostId) {
         Host host = hostRepository.getById(hostId);
         List<Space> spaces = spaceRepository.findAllByHost(host);
@@ -67,23 +73,6 @@ public class SpaceService {
                 .getId();
     }
 
-    public SpaceResponse findSpace(final Long hostId, final Long spaceId) {
-        Host host = hostRepository.getById(hostId);
-        Space space = spaceRepository.getByHostAndId(host, spaceId);
-        return SpaceResponse.from(space);
-    }
-
-    @Transactional
-    public void changeSpace(final Long hostId, final Long spaceId, final SpaceChangeRequest request) {
-        Host host = hostRepository.getById(hostId);
-        Space space = spaceRepository.getByHostAndId(host, spaceId);
-        Name changeName = new Name(request.getName());
-        checkDuplicateSpaceName(changeName, host, space);
-
-        space.changeName(changeName);
-        space.changeImageUrl(request.getImageUrl());
-    }
-
     @Transactional
     public void removeSpace(final Long hostId, final Long spaceId) {
         Host host = hostRepository.getById(hostId);
@@ -99,6 +88,17 @@ public class SpaceService {
         sectionRepository.deleteAllInBatch(sections);
         jobRepository.deleteAllInBatch(jobs);
         spaceRepository.deleteById(spaceId);
+    }
+
+    @Transactional
+    public void changeSpace(final Long hostId, final Long spaceId, final SpaceChangeRequest request) {
+        Host host = hostRepository.getById(hostId);
+        Space space = spaceRepository.getByHostAndId(host, spaceId);
+        Name changeName = new Name(request.getName());
+        checkDuplicateSpaceName(changeName, host, space);
+
+        space.changeName(changeName);
+        space.changeImageUrl(request.getImageUrl());
     }
 
     private void checkDuplicateSpaceName(final Name spaceName, final Host host) {

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -10,7 +10,6 @@ import com.woowacourse.gongcheck.auth.application.EntranceCodeProvider;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.presentation.request.SpacePasswordChangeRequest;
 import com.woowacourse.gongcheck.exception.NotFoundException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -32,52 +31,42 @@ class HostServiceTest {
     @Autowired
     private EntranceCodeProvider entranceCodeProvider;
 
+    abstract class Host가_존재한다면 {
+        protected final Host host = repository.save(Host_생성("1234", 1L));
+    }
+
     @Nested
     class changeSpacePassword_메소드는 {
 
         @Nested
-        class 존재하는_Host의_id와_수정할_패스워드를_받는_경우 {
+        class 존재하는_HostId와_수정할_패스워드를_입력받는다면 extends Host가_존재한다면 {
 
-            private static final String ORIGIN_PASSWORD = "1234";
             private static final String CHANGING_PASSWORD = "4567";
-            private static final long GITHUB_ID = 1234L;
 
-            private SpacePasswordChangeRequest spacePasswordChangeRequest;
-            private Long hostId;
-
-            @BeforeEach
-            void setUp() {
-                spacePasswordChangeRequest = new SpacePasswordChangeRequest(CHANGING_PASSWORD);
-                hostId = repository.save(Host_생성(ORIGIN_PASSWORD, GITHUB_ID))
-                        .getId();
-            }
+            private final SpacePasswordChangeRequest spacePasswordChangeRequest = new SpacePasswordChangeRequest(
+                    CHANGING_PASSWORD);
 
             @Test
             void 패스워드를_수정한다() {
-                hostService.changeSpacePassword(hostId, spacePasswordChangeRequest);
-                Host actual = repository.getById(Host.class, hostId);
+                hostService.changeSpacePassword(host.getId(), spacePasswordChangeRequest);
+                Host actual = repository.getById(Host.class, host.getId());
 
                 assertThat(actual.getSpacePassword().getValue()).isEqualTo(CHANGING_PASSWORD);
             }
         }
 
         @Nested
-        class 존재하지_않는_Host의_id를_받는_경우 {
+        class 존재하지_않는_HostId를_입력받는다면 {
 
             private static final String CHANGING_PASSWORD = "4567";
+            private static final long NON_EXIST_HOST_ID = 0L;
 
-            private SpacePasswordChangeRequest spacePasswordChangeRequest;
-            private Long hostId;
-
-            @BeforeEach
-            void setUp() {
-                spacePasswordChangeRequest = new SpacePasswordChangeRequest(CHANGING_PASSWORD);
-                hostId = 0L;
-            }
+            private final SpacePasswordChangeRequest spacePasswordChangeRequest = new SpacePasswordChangeRequest(
+                    CHANGING_PASSWORD);
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> hostService.changeSpacePassword(hostId, spacePasswordChangeRequest))
+                assertThatThrownBy(() -> hostService.changeSpacePassword(NON_EXIST_HOST_ID, spacePasswordChangeRequest))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 호스트입니다.");
             }
@@ -88,31 +77,24 @@ class HostServiceTest {
     class createEntranceCode_메소드는 {
 
         @Nested
-        class 존재하는_Host의_id를_받는_경우 {
+        class 존재하는_HostId를_입력받는다면 extends Host가_존재한다면 {
 
-            private Long hostId;
-            private String expected;
-
-            @BeforeEach
-            void setUp() {
-                hostId = repository.save(Host_생성("1234", 1111L))
-                        .getId();
-                expected = entranceCodeProvider.createEntranceCode(hostId);
-            }
+            private final Long hostId = host.getId();
+            private final String expected = entranceCodeProvider.createEntranceCode(hostId);
 
             @Test
-            void 입장코드를_반환한다() {
+            void entranceCode를_반환한다() {
                 String actual = hostService.createEntranceCode(hostId);
                 assertThat(actual).isEqualTo(expected);
             }
         }
 
         @Nested
-        class 존재하지_않는_Host의_id를_받는_경우 {
+        class 존재하지_않는_HostId를_입력받는다면 {
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> hostService.createEntranceCode(0L))
+                assertThatThrownBy(() -> hostService.createEntranceCode(1L))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 호스트입니다.");
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @ApplicationTest
-@DisplayName("HostService 클래스")
+@DisplayName("HostService 클래스의")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class HostServiceTest {
 
@@ -31,7 +31,7 @@ class HostServiceTest {
     @Autowired
     private EntranceCodeProvider entranceCodeProvider;
 
-    abstract class Host가_존재한다면 {
+    abstract class Host가_존재하는_경우 {
         protected final Host host = repository.save(Host_생성("1234", 1L));
     }
 
@@ -39,7 +39,7 @@ class HostServiceTest {
     class changeSpacePassword_메소드는 {
 
         @Nested
-        class 존재하는_HostId와_수정할_패스워드를_입력받는다면 extends Host가_존재한다면 {
+        class 존재하는_HostId와_수정할_패스워드를_입력받는_경우 extends Host가_존재하는_경우 {
 
             private static final String CHANGING_PASSWORD = "4567";
 
@@ -56,7 +56,7 @@ class HostServiceTest {
         }
 
         @Nested
-        class 존재하지_않는_HostId를_입력받는다면 {
+        class 존재하지_않는_HostId를_입력받는_경우 {
 
             private static final String CHANGING_PASSWORD = "4567";
             private static final long NON_EXIST_HOST_ID = 0L;
@@ -77,7 +77,7 @@ class HostServiceTest {
     class createEntranceCode_메소드는 {
 
         @Nested
-        class 존재하는_HostId를_입력받는다면 extends Host가_존재한다면 {
+        class 존재하는_HostId를_입력받는_경우 extends Host가_존재하는_경우 {
 
             private final Long hostId = host.getId();
             private final String expected = entranceCodeProvider.createEntranceCode(hostId);
@@ -90,7 +90,7 @@ class HostServiceTest {
         }
 
         @Nested
-        class 존재하지_않는_HostId를_입력받는다면 {
+        class 존재하지_않는_HostId를_입력받는_경우 {
 
             @Test
             void 예외를_발생시킨다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -31,18 +31,15 @@ class HostServiceTest {
     @Autowired
     private EntranceCodeProvider entranceCodeProvider;
 
-    abstract class Host가_존재하는_경우 {
-        protected final Host host = repository.save(Host_생성("1234", 1L));
-    }
-
     @Nested
     class changeSpacePassword_메소드는 {
 
         @Nested
-        class 존재하는_HostId와_수정할_패스워드를_입력받는_경우 extends Host가_존재하는_경우 {
+        class 존재하는_HostId와_수정할_패스워드를_입력받는_경우 {
 
             private static final String CHANGING_PASSWORD = "4567";
 
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final SpacePasswordChangeRequest spacePasswordChangeRequest = new SpacePasswordChangeRequest(
                     CHANGING_PASSWORD);
 
@@ -77,14 +74,14 @@ class HostServiceTest {
     class createEntranceCode_메소드는 {
 
         @Nested
-        class 존재하는_HostId를_입력받는_경우 extends Host가_존재하는_경우 {
+        class 존재하는_HostId를_입력받는_경우 {
 
-            private final Long hostId = host.getId();
-            private final String expected = entranceCodeProvider.createEntranceCode(hostId);
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final String expected = entranceCodeProvider.createEntranceCode(host.getId());
 
             @Test
             void entranceCode를_반환한다() {
-                String actual = hostService.createEntranceCode(hostId);
+                String actual = hostService.createEntranceCode(host.getId());
                 assertThat(actual).isEqualTo(expected);
             }
         }
@@ -92,9 +89,11 @@ class HostServiceTest {
         @Nested
         class 존재하지_않는_HostId를_입력받는_경우 {
 
+            private static final long NON_EXIST_HOST_ID = 0L;
+
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> hostService.createEntranceCode(1L))
+                assertThatThrownBy(() -> hostService.createEntranceCode(NON_EXIST_HOST_ID))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 호스트입니다.");
             }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -28,7 +28,6 @@ import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -50,14 +49,6 @@ class SpaceServiceTest {
     @Autowired
     private SpaceRepository spaceRepository;
 
-    abstract class 다른_Host가_소유한_Space인_경우 {
-
-        protected Space 다른_Host가_소유한_Space() {
-            Host host = repository.save(Host_생성("1234", 2345L));
-            return repository.save(Space_생성(host, "잠실 캠퍼스"));
-        }
-    }
-
     @Nested
     class findSpace_메서드는 {
 
@@ -66,7 +57,7 @@ class SpaceServiceTest {
 
             private static final String SPACE_NAME = "잠실 캠퍼스";
 
-            private final Host host = repository.save(Host_생성("1234", 2345L));
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final Space space = repository.save(Space_생성(host, SPACE_NAME));
 
             @Test
@@ -81,10 +72,11 @@ class SpaceServiceTest {
         }
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 {
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
-            private final Space space = 다른_Host가_소유한_Space();
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Host anotherHost = repository.save(Host_생성("1234", 2L));
+            private final Space space = repository.save(Space_생성(anotherHost, "잠실 캠퍼스"));
 
             @Test
             void 예외를_발생시킨다() {
@@ -99,17 +91,12 @@ class SpaceServiceTest {
 
             private static final long NON_EXIST_HOST_ID = 0L;
 
-            private Space space;
-
-            @BeforeEach
-            void setUp() {
-                Host host = repository.save(Host_생성("1234", 1234L));
-                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-            }
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Space dummySpace = repository.save(Space_생성(host, "잠실 캠퍼스"));
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.findSpace(NON_EXIST_HOST_ID, space.getId()))
+                assertThatThrownBy(() -> spaceService.findSpace(NON_EXIST_HOST_ID, dummySpace.getId()))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 호스트입니다.");
             }
@@ -118,11 +105,13 @@ class SpaceServiceTest {
         @Nested
         class 존재하지_않는_Space_id를_입력받은_경우 {
 
-            private Host host = host = repository.save(Host_생성("1234", 1234L));
+            private static final long NON_EXIST_SPACE_ID = 0L;
+
+            private final Host host = repository.save(Host_생성("1234", 1L));
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.findSpace(host.getId(), 0L))
+                assertThatThrownBy(() -> spaceService.findSpace(host.getId(), NON_EXIST_SPACE_ID))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 공간입니다.");
             }
@@ -148,7 +137,7 @@ class SpaceServiceTest {
         @Nested
         class 올바른_입력을_받는_경우 {
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final SpacesResponse expected = SpacesResponse.from(
                     repository.saveAll(List.of(Space_생성(host, "잠실 캠퍼스"), Space_생성(host, "선릉 캠퍼스"),
                             Space_생성(host, "양평같은방"))));
@@ -170,7 +159,7 @@ class SpaceServiceTest {
         @Nested
         class 입력받은_Space_이름이_Host가_소유한_Space의_이름과_중복되는_경우 {
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final SpaceCreateRequest request = new SpaceCreateRequest(
                     repository.save(Space_생성(host, "잠실 캠퍼스")).getName().getValue(),
                     "https://image.gongcheck.shop/123sdf5");
@@ -205,7 +194,7 @@ class SpaceServiceTest {
             private static final String SPACE_NAME = "잠실 캠퍼스";
             private static final String SPACE_IMAGE_URL = "https://image.gongcheck.shop/123sdf5";
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final SpaceCreateRequest request = new SpaceCreateRequest(SPACE_NAME, SPACE_IMAGE_URL);
 
             @Test
@@ -239,22 +228,24 @@ class SpaceServiceTest {
         }
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 {
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
-            private final Space space = 다른_Host가_소유한_Space();
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Host anotherHost = repository.save(Host_생성("1234", 2L));
+            private final Space space = repository.save(Space_생성(anotherHost, "잠실 캠퍼스"));
 
             @Test
             void 예외를_발생시킨다() {
                 assertThatThrownBy(() -> spaceService.removeSpace(host.getId(), space.getId()))
-                        .isInstanceOf(NotFoundException.class);
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 공간입니다.");
             }
         }
 
         @Nested
         class 올바른_입력을_받는_경우 {
 
-            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Host host = repository.save(Host_생성("1234", 1L));
             private final Space space = repository.save(Space_생성(host, "잠실 캠퍼스"));
             private final Job job = repository.save(Job_생성(space, "청소"));
             private final Section section = repository.save(Section_생성(job, "대강의실"));
@@ -314,10 +305,11 @@ class SpaceServiceTest {
         }
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_소유하지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하지_않은_경우 {
 
             private final Host host = repository.save(Host_생성("1234", 1L));
-            private final Space space = 다른_Host가_소유한_Space();
+            private final Host anotherHost = repository.save(Host_생성("1234", 2L));
+            private final Space space = repository.save(Space_생성(anotherHost, "잠실 캠퍼스"));
             private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest("changeName",
                     "changeImageUrl");
 
@@ -334,14 +326,11 @@ class SpaceServiceTest {
         class 입력받은_Space의_이름이_입력받은_Host가_소유한_Space_이름과_중복되는_경우 {
 
             private static final String SPACE_NAME = "잠실 캠퍼스";
+
             private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Space existSpace = repository.save(Space_생성(host, SPACE_NAME));
             private final Space spaceToChangeName = repository.save(Space_생성(host, "선릉 캠퍼스"));
             private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest(SPACE_NAME, "image");
-
-            @BeforeEach
-            void setUp() {
-                repository.save(Space_생성(host, SPACE_NAME));
-            }
 
             @Test
             void 예외를_발생시킨다() {

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SpaceServiceTest.java
@@ -18,11 +18,15 @@ import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.domain.job.Job;
 import com.woowacourse.gongcheck.core.domain.section.Section;
 import com.woowacourse.gongcheck.core.domain.space.Space;
+import com.woowacourse.gongcheck.core.domain.space.SpaceRepository;
 import com.woowacourse.gongcheck.core.domain.task.RunningTask;
 import com.woowacourse.gongcheck.core.domain.task.Task;
+import com.woowacourse.gongcheck.core.domain.vo.Name;
+import com.woowacourse.gongcheck.core.presentation.request.SpaceChangeRequest;
 import com.woowacourse.gongcheck.core.presentation.request.SpaceCreateRequest;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,118 +47,14 @@ class SpaceServiceTest {
     @Autowired
     private SupportRepository repository;
 
-    @Nested
-    class findSpaces_메서드는 {
+    @Autowired
+    private SpaceRepository spaceRepository;
 
-        @Nested
-        class 존재하지_않는_Host_id를_입력받는_경우 {
+    abstract class 다른_Host가_소유한_Space인_경우 {
 
-            @Test
-            void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.findSpaces(0L))
-                        .isInstanceOf(NotFoundException.class)
-                        .hasMessageContaining("존재하지 않는 호스트입니다.");
-            }
-        }
-
-        @Nested
-        class 존재하는_Host의_id를_입력받은_경우 {
-
-            private Host host;
-            private SpacesResponse expected;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-
-                Space space_1 = Space_생성(host, "잠실 캠퍼스");
-                Space space_2 = Space_생성(host, "선릉 캠퍼스");
-                Space space_3 = Space_생성(host, "양평같은방");
-                List<Space> spaces = repository.saveAll(List.of(space_1, space_2, space_3));
-
-                expected = SpacesResponse.from(spaces);
-            }
-
-            @Test
-            void 해당_Host가_소유한_Space를_응답으로_반환한다() {
-                SpacesResponse actual = spaceService.findSpaces(host.getId());
-
-                assertThat(actual.getSpaces())
-                        .usingRecursiveFieldByFieldElementComparator()
-                        .isEqualTo(expected.getSpaces());
-            }
-        }
-    }
-
-    @Nested
-    class createSpace_메서드는 {
-
-        @Nested
-        class Host가_입력받은_Space_이름과_같은_Space를_이미_가지고_있는_경우 {
-
-            private Host host;
-            private SpaceCreateRequest request;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-                Space space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-                request = new SpaceCreateRequest(space.getName().getValue(), "https://image.gongcheck.shop/123sdf5");
-            }
-
-            @Test
-            void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.createSpace(host.getId(), request))
-                        .isInstanceOf(BusinessException.class)
-                        .hasMessageContaining("이미 존재하는 이름입니다.");
-            }
-        }
-
-        @Nested
-        class 존재하지_않는_Host_id를_입력받은_경우 {
-
-            private static final long NON_EXIST_HOST_ID = 0L;
-
-            private SpaceCreateRequest request;
-
-            @BeforeEach
-            void setUp() {
-                request = new SpaceCreateRequest("이것은 유일한 Space이름", "https://image.gongcheck.shop/123sdf5");
-            }
-
-            @Test
-            void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.createSpace(NON_EXIST_HOST_ID, request))
-                        .isInstanceOf(NotFoundException.class)
-                        .hasMessageContaining("존재하지 않는 호스트입니다.");
-            }
-        }
-
-        @Nested
-        class 입력받은_Host가_존재하는_경우 {
-
-            private static final String SPACE_NAME = "잠실 캠퍼스";
-            private static final String SPACE_IMAGE_URL = "https://image.gongcheck.shop/123sdf5";
-
-            private Host host;
-            private SpaceCreateRequest request;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-                request = new SpaceCreateRequest(SPACE_NAME, SPACE_IMAGE_URL);
-            }
-
-            @Test
-            void Space를_생성한다() {
-                Long spaceId = spaceService.createSpace(host.getId(), request);
-                Space actual = repository.getById(Space.class, spaceId);
-
-                assertAll(
-                        () -> assertThat(actual.getName().getValue()).isEqualTo(SPACE_NAME),
-                        () -> assertThat(actual.getImageUrl()).isEqualTo(SPACE_IMAGE_URL)
-                );
-            }
+        protected Space 다른_Host가_소유한_Space() {
+            Host host = repository.save(Host_생성("1234", 2345L));
+            return repository.save(Space_생성(host, "잠실 캠퍼스"));
         }
     }
 
@@ -162,21 +62,15 @@ class SpaceServiceTest {
     class findSpace_메서드는 {
 
         @Nested
-        class Space_목록이_존재하는_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하고_있는_경우 {
 
             private static final String SPACE_NAME = "잠실 캠퍼스";
 
-            private Host host;
-            private Space space;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 2345L));
-                space = repository.save(Space_생성(host, SPACE_NAME));
-            }
+            private final Host host = repository.save(Host_생성("1234", 2345L));
+            private final Space space = repository.save(Space_생성(host, SPACE_NAME));
 
             @Test
-            void Job_목록을_조회한다() {
+            void Space_응답을_반환한다() {
                 SpaceResponse actual = spaceService.findSpace(host.getId(), space.getId());
 
                 assertAll(
@@ -187,21 +81,14 @@ class SpaceServiceTest {
         }
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_가지고_있지_않은_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
 
-            private Space space;
-            private Host anotherHost;
-
-            @BeforeEach
-            void setUp() {
-                Host host = repository.save(Host_생성("1234", 1234L));
-                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-                anotherHost = repository.save(Host_생성("1234", 2345L));
-            }
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Space space = 다른_Host가_소유한_Space();
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.findSpace(anotherHost.getId(), space.getId()))
+                assertThatThrownBy(() -> spaceService.findSpace(host.getId(), space.getId()))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 공간입니다.");
             }
@@ -231,12 +118,7 @@ class SpaceServiceTest {
         @Nested
         class 존재하지_않는_Space_id를_입력받은_경우 {
 
-            private Host host;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-            }
+            private Host host = host = repository.save(Host_생성("1234", 1234L));
 
             @Test
             void 예외를_발생시킨다() {
@@ -245,28 +127,95 @@ class SpaceServiceTest {
                         .hasMessageContaining("존재하지 않는 공간입니다.");
             }
         }
+    }
+
+    @Nested
+    class findSpaces_메서드는 {
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_소유하고_있는_경우 {
+        class 존재하지_않는_HostId를_입력받는_경우 {
 
-            private static final String SPACE_NAME = "잠실 캠퍼스";
-
-            private Host host;
-            private Space space;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-                space = repository.save(Space_생성(host, SPACE_NAME));
-            }
+            private static final long NON_EXIST_HOST_ID = 0L;
 
             @Test
-            void Space_응답을_반환한다() {
-                SpaceResponse actual = spaceService.findSpace(host.getId(), space.getId());
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(() -> spaceService.findSpaces(NON_EXIST_HOST_ID))
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 호스트입니다.");
+            }
+        }
+
+        @Nested
+        class 올바른_입력을_받는_경우 {
+
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final SpacesResponse expected = SpacesResponse.from(
+                    repository.saveAll(List.of(Space_생성(host, "잠실 캠퍼스"), Space_생성(host, "선릉 캠퍼스"),
+                            Space_생성(host, "양평같은방"))));
+
+            @Test
+            void 해당_Host가_소유한_Space를_응답으로_반환한다() {
+                SpacesResponse actual = spaceService.findSpaces(host.getId());
+
+                assertThat(actual.getSpaces())
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .isEqualTo(expected.getSpaces());
+            }
+        }
+    }
+
+    @Nested
+    class createSpace_메서드는 {
+
+        @Nested
+        class 입력받은_Space_이름이_Host가_소유한_Space의_이름과_중복되는_경우 {
+
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final SpaceCreateRequest request = new SpaceCreateRequest(
+                    repository.save(Space_생성(host, "잠실 캠퍼스")).getName().getValue(),
+                    "https://image.gongcheck.shop/123sdf5");
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(() -> spaceService.createSpace(host.getId(), request))
+                        .isInstanceOf(BusinessException.class)
+                        .hasMessageContaining("이미 존재하는 이름입니다.");
+            }
+        }
+
+        @Nested
+        class 존재하지_않는_HostId를_입력받는_경우 {
+
+            private static final long NON_EXIST_HOST_ID = 0L;
+
+            private final SpaceCreateRequest request = new SpaceCreateRequest("이것은 유일한 Space이름",
+                    "https://image.gongcheck.shop/123sdf5");
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(() -> spaceService.createSpace(NON_EXIST_HOST_ID, request))
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 호스트입니다.");
+            }
+        }
+
+        @Nested
+        class 올바른_입력을_받는_경우 {
+
+            private static final String SPACE_NAME = "잠실 캠퍼스";
+            private static final String SPACE_IMAGE_URL = "https://image.gongcheck.shop/123sdf5";
+
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final SpaceCreateRequest request = new SpaceCreateRequest(SPACE_NAME, SPACE_IMAGE_URL);
+
+            @Test
+            void Space를_생성한다() {
+                Long spaceId = spaceService.createSpace(host.getId(), request);
+                Space actual = repository.getById(Space.class, spaceId);
 
                 assertAll(
-                        () -> assertThat(actual.getId()).isEqualTo(space.getId()),
-                        () -> assertThat(actual.getName()).isEqualTo(SPACE_NAME)
+                        () -> assertThat(actual.getName().getValue()).isEqualTo(SPACE_NAME),
+                        () -> assertThat(actual.getImageUrl()).isEqualTo(SPACE_IMAGE_URL)
                 );
             }
         }
@@ -279,62 +228,38 @@ class SpaceServiceTest {
         class 입력받은_Host_id가_존재하지_않는_경우 {
 
             private static final long NON_EXIST_HOST_ID = 0L;
-
-            private Space space;
-
-            @BeforeEach
-            void setUp() {
-                Host host = repository.save(Host_생성("1234", 1234L));
-                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-            }
+            private static final long DUMMY_SPACE_ID = 1L;
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.removeSpace(NON_EXIST_HOST_ID, space.getId()))
+                assertThatThrownBy(() -> spaceService.removeSpace(NON_EXIST_HOST_ID, DUMMY_SPACE_ID))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessageContaining("존재하지 않는 호스트입니다.");
             }
         }
 
         @Nested
-        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 {
+        class 입력받은_Host가_입력받은_Space를_소유하고_있지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
 
-            private Host anotherHost;
-            private Space space;
-
-            @BeforeEach
-            void setUp() {
-                Host host = repository.save(Host_생성("1234", 1234L));
-                anotherHost = repository.save(Host_생성("1234", 4567L));
-                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-            }
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Space space = 다른_Host가_소유한_Space();
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> spaceService.removeSpace(anotherHost.getId(), space.getId()))
+                assertThatThrownBy(() -> spaceService.removeSpace(host.getId(), space.getId()))
                         .isInstanceOf(NotFoundException.class);
             }
         }
 
         @Nested
-        class 입력받은_Space_id가_존재하면 {
+        class 올바른_입력을_받는_경우 {
 
-            private Host host;
-            private Space space;
-            private Job job;
-            private Section section;
-            private Task task;
-            private RunningTask runningTask;
-
-            @BeforeEach
-            void setUp() {
-                host = repository.save(Host_생성("1234", 1234L));
-                space = repository.save(Space_생성(host, "잠실 캠퍼스"));
-                job = repository.save(Job_생성(space, "청소"));
-                section = repository.save(Section_생성(job, "대강의실"));
-                task = repository.save(Task_생성(section, "책상 닦기"));
-                runningTask = repository.save(RunningTask_생성(task.getId(), false));
-            }
+            private final Host host = repository.save(Host_생성("1234", 1234L));
+            private final Space space = repository.save(Space_생성(host, "잠실 캠퍼스"));
+            private final Job job = repository.save(Job_생성(space, "청소"));
+            private final Section section = repository.save(Section_생성(job, "대강의실"));
+            private final Task task = repository.save(Task_생성(section, "책상 닦기"));
+            private final RunningTask runningTask = repository.save(RunningTask_생성(task.getId(), false));
 
             @Test
             void 해당_Space_및_관련된_Job_Section_Task_RunningTask를_삭제한다() {
@@ -346,6 +271,110 @@ class SpaceServiceTest {
                         () -> assertThat(repository.findById(Section.class, section.getId())).isEmpty(),
                         () -> assertThat(repository.findById(Task.class, task.getId())).isEmpty(),
                         () -> assertThat(repository.findById(RunningTask.class, runningTask.getTaskId())).isEmpty()
+                );
+            }
+        }
+    }
+
+    @Nested
+    class changeSpace_메서드는 {
+
+        @Nested
+        class 입력받은_Host가_존재하지_않는_경우 {
+
+            private static final long NON_EXIST_HOST_ID = 0L;
+            private static final long DUMMY_SPACE_ID = 1L;
+
+            private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest("잠실 캠퍼스", "changeImageUrl");
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(
+                        () -> spaceService.changeSpace(NON_EXIST_HOST_ID, DUMMY_SPACE_ID, spaceChangeRequest))
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 호스트입니다.");
+            }
+        }
+
+        @Nested
+        class 입력받은_Space가_존재하지_않는_경우 {
+
+            private static final long NON_EXIST_SPACE_ID = 0L;
+
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest("잠실 캠퍼스", "changeImageUrl");
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(
+                        () -> spaceService.changeSpace(host.getId(), NON_EXIST_SPACE_ID, spaceChangeRequest))
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 공간입니다.");
+            }
+        }
+
+        @Nested
+        class 입력받은_Host가_입력받은_Space를_소유하지_않은_경우 extends 다른_Host가_소유한_Space인_경우 {
+
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Space space = 다른_Host가_소유한_Space();
+            private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest("changeName",
+                    "changeImageUrl");
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(
+                        () -> spaceService.changeSpace(host.getId(), space.getId(), spaceChangeRequest))
+                        .isInstanceOf(NotFoundException.class)
+                        .hasMessageContaining("존재하지 않는 공간입니다.");
+            }
+        }
+
+        @Nested
+        class 입력받은_Space의_이름이_입력받은_Host가_소유한_Space_이름과_중복되는_경우 {
+
+            private static final String SPACE_NAME = "잠실 캠퍼스";
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Space spaceToChangeName = repository.save(Space_생성(host, "선릉 캠퍼스"));
+            private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest(SPACE_NAME, "image");
+
+            @BeforeEach
+            void setUp() {
+                repository.save(Space_생성(host, SPACE_NAME));
+            }
+
+            @Test
+            void 예외를_발생시킨다() {
+                assertThatThrownBy(
+                        () -> spaceService.changeSpace(host.getId(), spaceToChangeName.getId(), spaceChangeRequest))
+                        .isInstanceOf(BusinessException.class)
+                        .hasMessageContaining("이미 존재하는 이름입니다.");
+            }
+        }
+
+        @Nested
+        class 올바른_입력을_받는_경우 {
+
+            private static final String CHANGE_NAME = "잠실 캠퍼스";
+            private static final String CHANGE_IMG_URL = "changeUrl";
+
+            private final Host host = repository.save(Host_생성("1234", 1L));
+            private final Space space = repository.save(Space.builder()
+                    .host(host)
+                    .name(new Name("잠실 캠퍼스"))
+                    .imageUrl("imageUrl")
+                    .createdAt(LocalDateTime.now())
+                    .build());
+            private final SpaceChangeRequest spaceChangeRequest = new SpaceChangeRequest(CHANGE_NAME, CHANGE_IMG_URL);
+
+            @Test
+            void Space_이름을_변경한다() {
+                spaceService.changeSpace(host.getId(), space.getId(), spaceChangeRequest);
+                Space actual = spaceRepository.getByHostAndId(host, space.getId());
+
+                assertAll(
+                        () -> assertThat(actual.getName()).isEqualTo(new Name(CHANGE_NAME)),
+                        () -> assertThat(actual.getImageUrl()).isEqualTo(CHANGE_IMG_URL)
                 );
             }
         }


### PR DESCRIPTION
## issue
- resolve #517 

## 코드 설명

HostService와 SpaceServiceTest의 가독성을 개선해보았습니다. 

## 변경점

### Setup 메서드에서 초기화하던 것을 변수 선언에서 한번에 처리했습니다.
 
선언과 초기화가 분리되어 있다보니 해당 변수가 어떻게 초기화 되어있는지 확인하는 과정이 번거롭다고 판단했기 때문입니다. Context 부분은 테스트할 메서드의 입력 파라미터를 설명하는 것이 주 목적인데, 선언과 할당을 같이 하는 것이 이 목적을 더 잘 달성한다고 생각했습니다.

### 중복되는 Context는 abstract context를 선언하여 재사용하는 방식으로 구성했습니다.

### 해피케이스의 Context를 단순화하였습니다.

예를들어, changeSpace 메서드의 해피케이스는, `입력받은 Host가 존재하고 입력받은 Space가 입력받은 Host의 소유이며, 입력받은 ChangeSpaceRequest의 name이 기존에 있던 Space와 중복되지 않는 경우`입니다.

이를 Context에서 자세하게 서술하는 것은 불가능하다고 생각합니다. 또 이를 단순화하여 `존재하는 Host와 존재하는 Space를 입력받는 경우`라고 서술하면, 해피케이스의 Context를 불완전하게 전달하여 코드를 읽는 사람에게 잘못된 정보를 줄 수 있다고 생각합니다. 따라서 언해피 케이스는 다른 예외 Context에서 설명하고 해피케이스는 단순히 `올바른 입력을 받는 경우`라고 서술하였습니다.

---

이후 다른 서비스 테스트를 리팩토링하기 전에 샘플용으로 팀원들의 의견을 받아보고자 먼저 PR 날려봅니다.

추가적으로 
* SpaceService의 changeSpace 메서드의 테스트가 누락된 것을 발견하여 추가했습니다.
* SpaceService의 메서드 순서를 테스트 순서와 일관되도록 정렬하였습니다.

