### PR TITLE
[BE] SSE timeout시 발생하는 예외 회피 코드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/exception/ControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 
 @RestControllerAdvice
 @Slf4j
@@ -49,6 +50,11 @@ public class ControllerAdvice {
     @ExceptionHandler(InfrastructureException.class)
     public ResponseEntity<ErrorResponse> handleInfrastructureException(final CustomException e) {
         return ResponseEntity.internalServerError().body(ErrorResponse.from(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public void escapeFromAsyncRequestTimeoutException() {
+        // do nothing
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## issue
- resolve #534 

## 코드 설명

SSE 만료 시 자동으로 `AsyncRequestTimeoutException`이 발생합니다. 연결이 만료되었을 때 자동으로 브라우저에서 재연결 요청을 하기 때문에 무시해도 되는 예외이지만 현재 이에 대한 예외처리가 없어서 error log에 이 예외가 계속 남습니다.

따라서 `ControllerAdvice`에서 해당 예외를 무시하는 코드를 추가하였습니다.

빈 코드블럭이 실수로 작성되었다는 오해를 피하고자 명시적으로 do nothing이라는 주석을 달았는데, 필요없다고 판단되면 코멘트 남겨주세요. 지우겠습니다.
