### PR TITLE
[FE] 관리자 화면을 모바일 및 태블릿에서도 볼 수 있도록 한다.

### DIFF
--- a/frontend/src/components/common/Button/styles.ts
+++ b/frontend/src/components/common/Button/styles.ts
@@ -4,10 +4,10 @@ import theme from '@/styles/theme';
 
 const button = css`
   background: ${theme.colors.primary};
-  width: 224px;
+  width: auto;
   height: 48px;
   border-radius: 12px;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   color: ${theme.colors.white};
   margin: 24px;

--- a/frontend/src/components/common/GitHubLoginButton/styles.ts
+++ b/frontend/src/components/common/GitHubLoginButton/styles.ts
@@ -4,15 +4,16 @@ const wrapper = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 260px;
+  width: auto;
   border-radius: 24px;
   color: white;
   background-color: #21262c;
+  padding: 0 16px;
 `;
 
 const text = css`
-  margin-left: 16px;
-  font-size: 24px;
+  margin-left: 12px;
+  font-size: 18px;
 `;
 
 const styles = { wrapper, text };

--- a/frontend/src/components/common/SlideMenu/index.tsx
+++ b/frontend/src/components/common/SlideMenu/index.tsx
@@ -1,0 +1,12 @@
+import styles from './styles';
+
+interface SlideMenuProps {
+  children: React.ReactNode;
+  isShowMenu: boolean | null;
+}
+
+const SlideMenu: React.FC<SlideMenuProps> = ({ children, isShowMenu }) => {
+  return <div css={styles.slideMenu(isShowMenu)}>{children}</div>;
+};
+
+export default SlideMenu;

--- a/frontend/src/components/common/SlideMenu/styles.ts
+++ b/frontend/src/components/common/SlideMenu/styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react';
+
+import animation from '@/styles/animation';
+import theme from '@/styles/theme';
+
+const slideMenu = (isShowMenu: boolean | null) => css`
+  position: absolute;
+  min-height: 100vh;
+  background-color: ${theme.colors.white};
+  z-index: 100;
+  width: 100%;
+  box-shadow: 0 -2px 2px 0px ${theme.colors.shadow30};
+  animation: ${isShowMenu === true ? animation.navigatorOpen : animation.navigatorClose} 0.2s ease-out;
+  animation-fill-mode: forwards;
+`;
+
+const styles = { slideMenu };
+
+export default styles;

--- a/frontend/src/components/host/ImageBox/styles.ts
+++ b/frontend/src/components/host/ImageBox/styles.ts
@@ -30,6 +30,7 @@ const imageChangeBox = (imageUrl: string, borderStyle?: string) => css`
 `;
 
 const imageInput = css`
+  width: 100%;
   opacity: 0;
   z-index: -1;
 `;

--- a/frontend/src/components/host/JobControl/styles.ts
+++ b/frontend/src/components/host/JobControl/styles.ts
@@ -11,29 +11,25 @@ const header = css`
   border-bottom: 1px solid ${theme.colors.gray300};
   padding: 16px 32px;
   font-size: 16px;
-
-  @media screen and (max-width: 720px) {
-    font-size: 14px;
-  }
 `;
 
 const createButton = css`
   margin: 0;
   margin-left: 12px;
-  font-size: 1.2em;
+  font-size: 1.1em;
   width: fit-content;
   height: fit-content;
-  padding: 12px;
+  padding: 8px 10px;
   background-color: ${theme.colors.green};
 `;
 
 const jobNameInput = css`
   border: none;
   border-radius: 12px;
-  width: 55%;
+  width: 64%;
   height: 1.5em;
   padding: 1em;
-  font-size: 1.5em;
+  font-size: 1.2em;
   font-weight: 500;
   margin: 12px 0;
   background-color: ${theme.colors.white};

--- a/frontend/src/components/host/JobListCard/index.tsx
+++ b/frontend/src/components/host/JobListCard/index.tsx
@@ -19,7 +19,7 @@ const JobListCard: React.FC<JobListCardProps> = ({ jobs }) => {
   return (
     <div css={styles.layout}>
       <div css={styles.title}>
-        <span>공간 업무 목록</span>
+        <p>업무 목록</p>
         <Button css={styles.newJobButton} onClick={onClickNewJobButton}>
           새 업무 생성
         </Button>
@@ -28,7 +28,7 @@ const JobListCard: React.FC<JobListCardProps> = ({ jobs }) => {
         {jobs.length === 0 ? (
           <div css={styles.empty}>
             <img src={emptyFolder} alt="" />
-            <div>생성된 업무가 없어요.</div>
+            <div>생성된 업무가 없습니다.</div>
           </div>
         ) : (
           jobs.map(job => <JobBox job={job} key={job.id} />)

--- a/frontend/src/components/host/JobListCard/styles.ts
+++ b/frontend/src/components/host/JobListCard/styles.ts
@@ -4,19 +4,27 @@ import theme from '@/styles/theme';
 
 const layout = css`
   min-width: 320px;
-  width: 100%;
-  height: 30.2rem;
   background-color: ${theme.colors.white};
   box-shadow: 2px 2px 2px 2px ${theme.colors.shadow10};
   border-radius: 8px;
+
+  @media screen and (min-width: 1024px) {
+    height: 452px;
+    width: 100%;
+  }
+
+  @media screen and (max-width: 1023px) {
+    height: 360px;
+    width: 90%;
+  }
 `;
 
 const title = css`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
-  font-size: 1.4rem;
+  padding: 0 24px;
+  font-size: 1.2rem;
   border-bottom: 1px solid ${theme.colors.gray300};
 `;
 
@@ -49,11 +57,8 @@ const jobList = css`
 const newJobButton = css`
   width: auto;
   height: 2rem;
-  padding: 6px 10px;
-  font-weight: 500;
-  font-size: 1rem;
+  font-size: 0.9rem;
   padding: 0 12px;
-
   margin: 0;
 `;
 

--- a/frontend/src/components/host/Menu/index.tsx
+++ b/frontend/src/components/host/Menu/index.tsx
@@ -1,20 +1,14 @@
-import useHostNavigation from './useHostNavigation';
+import useMenu from './useMenu';
 import { CgHomeAlt } from 'react-icons/cg';
 import { RiLockPasswordLine } from 'react-icons/ri';
 
-import navigationLogo from '@/assets/navigationLogo.png';
-
 import styles from './styles';
 
-const Navigation: React.FC = () => {
-  const { selectedSpaceId, spaceData, onClickPasswordUpdate, onClickSpace, onClickNewSpace } = useHostNavigation();
+const Menu = () => {
+  const { selectedSpaceId, spaceData, onClickPasswordUpdate, onClickSpace, onClickNewSpace } = useMenu();
 
   return (
-    <div css={styles.layout}>
-      <div css={styles.logo}>
-        <img src={navigationLogo} alt="" css={styles.logoImage} />
-      </div>
-
+    <>
       <div css={styles.category}>
         <span css={styles.categoryTitle}>Menu</span>
         <div css={styles.categoryList} onClick={onClickPasswordUpdate}>
@@ -47,8 +41,8 @@ const Navigation: React.FC = () => {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 
-export default Navigation;
+export default Menu;

--- a/frontend/src/components/host/Menu/styles.ts
+++ b/frontend/src/components/host/Menu/styles.ts
@@ -2,38 +2,6 @@ import { css } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
-const layout = css`
-  font-size: 16px;
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  width: 14em;
-  background-color: ${theme.colors.white};
-  box-shadow: 6px 0 8px ${theme.colors.gray350};
-  z-index: 1;
-
-  @media screen and (max-width: 1024px) {
-    font-size: 14px;
-  }
-  @media screen and (max-width: 720px) {
-    font-size: 12px;
-  }
-`;
-
-const logo = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 200px;
-`;
-
-const logoImage = css`
-  width: 160px;
-  height: 160px;
-`;
-
 const category = css`
   width: 100%;
   display: flex;
@@ -42,7 +10,7 @@ const category = css`
 `;
 
 const categoryTitle = css`
-  font-size: 1em;
+  font-size: 0.9em;
   font-weight: 600;
   color: ${theme.colors.gray800};
   margin: 8px 0;
@@ -103,9 +71,6 @@ const addNewSpace = css`
 `;
 
 const styles = {
-  layout,
-  logo,
-  logoImage,
   category,
   categoryTitle,
   categoryList,

--- a/frontend/src/components/host/Menu/useMenu.ts
+++ b/frontend/src/components/host/Menu/useMenu.ts
@@ -6,7 +6,7 @@ import apiSpace from '@/apis/space';
 
 import { ID } from '@/types';
 
-const useHostNavigation = () => {
+const useHostNavigator = () => {
   const navigate = useNavigate();
 
   const { spaceId } = useParams() as { spaceId: ID };
@@ -31,4 +31,4 @@ const useHostNavigation = () => {
   return { selectedSpaceId, spaceData, onClickPasswordUpdate, onClickSpace, onClickNewSpace };
 };
 
-export default useHostNavigation;
+export default useHostNavigator;

--- a/frontend/src/components/host/Navigator/LeftNavigator/index.tsx
+++ b/frontend/src/components/host/Navigator/LeftNavigator/index.tsx
@@ -1,0 +1,25 @@
+import Menu from '../../Menu';
+import { useNavigate } from 'react-router-dom';
+
+import logo from '@/assets/navigationLogo.png';
+
+import styles from './styles';
+
+const LeftNavigator: React.FC = () => {
+  const navigate = useNavigate();
+
+  const onClickLogo = () => {
+    if (location.pathname.split('/').length !== 4) navigate(-1);
+  };
+
+  return (
+    <div css={styles.layout}>
+      <div css={styles.logo} onClick={onClickLogo}>
+        <img css={styles.logoImage} src={logo} alt="" />
+      </div>
+      <Menu />
+    </div>
+  );
+};
+
+export default LeftNavigator;

--- a/frontend/src/components/host/Navigator/LeftNavigator/styles.ts
+++ b/frontend/src/components/host/Navigator/LeftNavigator/styles.ts
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const layout = css`
+  font-size: 16px;
+  height: 100vh;
+  width: 14em;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: ${theme.colors.white};
+  box-shadow: 6px 0 8px ${theme.colors.gray350};
+  z-index: 1;
+`;
+
+const logo = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 200px;
+  cursor: pointer;
+`;
+
+const logoImage = css`
+  width: 160px;
+  height: 160px;
+`;
+
+const styles = {
+  layout,
+  logo,
+  logoImage,
+};
+
+export default styles;

--- a/frontend/src/components/host/Navigator/TopNavigator/index.tsx
+++ b/frontend/src/components/host/Navigator/TopNavigator/index.tsx
@@ -1,0 +1,39 @@
+import Menu from '../../Menu';
+import isNull from '@/utils/isNull';
+import { useState } from 'react';
+import { BiMenu, BiX } from 'react-icons/bi';
+import { useNavigate } from 'react-router-dom';
+
+import SlideMenu from '@/components/common/SlideMenu';
+
+import logo from '@/assets/logoTitle.png';
+
+import styles from './styles';
+
+const TopNavigator: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [isShowMenu, setIsShowMenu] = useState<boolean | null>(null);
+
+  const onClickMenuIcon = () => setIsShowMenu(prev => !prev);
+
+  const onClickLogo = () => {
+    if (location.pathname.split('/').length !== 4) navigate(-1);
+  };
+
+  return (
+    <>
+      <div css={styles.layout}>
+        {isShowMenu ? <BiX size={32} onClick={onClickMenuIcon} /> : <BiMenu size={32} onClick={onClickMenuIcon} />}
+        <img css={styles.logo} src={logo} alt="" onClick={onClickLogo} />
+      </div>
+      {!isNull(isShowMenu) && (
+        <SlideMenu isShowMenu={isShowMenu}>
+          <Menu />
+        </SlideMenu>
+      )}
+    </>
+  );
+};
+
+export default TopNavigator;

--- a/frontend/src/components/host/Navigator/TopNavigator/styles.ts
+++ b/frontend/src/components/host/Navigator/TopNavigator/styles.ts
@@ -1,0 +1,39 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const layout = css`
+  font-size: 16px;
+  position: fixed;
+  top: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${theme.colors.white};
+  z-index: 1;
+
+  width: 100vw;
+  height: 64px;
+  box-shadow: 0 2px 2px 0px ${theme.colors.shadow30};
+
+  svg {
+    color: ${theme.colors.gray800};
+    cursor: pointer;
+    position: absolute;
+    left: 12px;
+  }
+`;
+
+const logo = css`
+  height: 40px;
+  transform: translateY(4px);
+  cursor: pointer;
+`;
+
+const styles = {
+  layout,
+  logo,
+};
+
+export default styles;

--- a/frontend/src/components/host/SectionCard/styles.ts
+++ b/frontend/src/components/host/SectionCard/styles.ts
@@ -7,10 +7,10 @@ const container = css`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 480px;
-  height: 360px;
+  min-width: 320px;
+  height: 356px;
   overflow-y: scroll;
-  padding: 32px;
+  padding: 40px 32px;
   background-color: ${theme.colors.white};
   box-shadow: 2px 2px 2px 2px ${theme.colors.shadow20};
   border-radius: 8px;
@@ -42,7 +42,6 @@ const titleWrapper = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 20px;
   margin-bottom: 8px;
   padding-bottom: 16px;
   border-bottom: 2px solid ${theme.colors.shadow20};
@@ -79,11 +78,10 @@ const newTaskButton = css`
 `;
 
 const input = css`
-  font-size: 18px;
-  line-height: 38px;
+  font-size: 16px;
   border: 1px solid ${theme.colors.shadow30};
   border-radius: 12px;
-  padding: 0 16px;
+  padding: 4px 16px;
   background-color: ${theme.colors.white};
   width: 80%;
 

--- a/frontend/src/components/host/SectionDetailModal/index.tsx
+++ b/frontend/src/components/host/SectionDetailModal/index.tsx
@@ -47,7 +47,7 @@ const SectionDetailModal: React.FC<SectionDetailModalProps> = props => {
           <img css={styles.image} src={imageUrl} alt="" onClick={() => fileInput.current?.click()} />
           <input
             type="file"
-            accept="image/gif, image/jpg, image/jpeg, image/png, image/svg"
+            accept="image/gif, image/jpg, image/jpeg, image/png, image/svg, , image/webp"
             ref={fileInput}
             onChange={onChangeImage}
           />
@@ -55,14 +55,14 @@ const SectionDetailModal: React.FC<SectionDetailModalProps> = props => {
             <textarea
               rows={4}
               value={description}
-              placeholder="사용자가 확인할 안내사항을 입력주세요. (128자이내)"
+              placeholder="사용자가 확인할 안내사항을 입력주세요."
               maxLength={128}
               onChange={onChangeText}
             />
             <span>{description?.length || 0}/128</span>
           </div>
           <Button css={styles.saveButton(isDisabledButton)} disabled={isDisabledButton} onClick={onClickSaveButton}>
-            저장
+            {target === 'section' ? '업무 정보 저장' : '작업 정보 저장'}
           </Button>
         </div>
         {isImageLoading && <LoadingOverlay />}

--- a/frontend/src/components/host/SectionDetailModal/styles.ts
+++ b/frontend/src/components/host/SectionDetailModal/styles.ts
@@ -3,7 +3,8 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const container = css`
-  width: 560px;
+  max-width: 480px;
+  width: 80%;
   background-color: ${theme.colors.white};
   display: flex;
   flex-direction: column;
@@ -15,8 +16,9 @@ const container = css`
 
   h1 {
     align-self: start;
-    font-size: 24px;
-    margin: 0 0 16px 32px;
+    font-size: 1.2rem;
+    margin: 0 0 8px 32px;
+    height: 24px;
   }
 
   svg {
@@ -32,9 +34,10 @@ const container = css`
 `;
 
 const image = css`
-  width: 400px;
-  height: 250px;
+  width: 90%;
+  margin-top: 8px;
   cursor: pointer;
+  border-radius: 8px;
 `;
 
 const description = css`
@@ -48,11 +51,11 @@ const description = css`
     outline: none;
     border: 2px solid ${theme.colors.shadow20};
     border-radius: 8px;
-    font-size: 16px;
+    font-size: 0.9rem;
     color: ${theme.colors.black};
     padding: 8px;
     ::placeholder {
-      font-size: 16px;
+      font-size: 0.9rem;
       color: ${theme.colors.gray500};
     }
     :focus {
@@ -72,7 +75,8 @@ const description = css`
 `;
 
 const saveButton = (isDisabledButton: boolean) => css`
-  font-size: 20px;
+  width: 90%;
+  font-size: 1rem;
   margin: 0;
   background-color: ${isDisabledButton ? theme.colors.gray400 : theme.colors.green};
 `;

--- a/frontend/src/components/host/SlackUrlBox/styles.ts
+++ b/frontend/src/components/host/SlackUrlBox/styles.ts
@@ -14,19 +14,23 @@ const form = css`
 `;
 
 const label = css`
-  font-size: 18px;
-  margin: 20px 0 8px 0;
+  font-size: 16px;
+  margin: 12px 0 8px 0;
+  padding: 0 4px;
   font-weight: 600;
   color: ${theme.colors.gray800};
 `;
 
 const input = css`
   width: 100%;
+  height: 36px;
 `;
 
 const button = css`
+  font-size: 0.8rem;
   margin: 0 8px;
-  width: 58px;
+  width: 48px;
+  height: 32px;
 `;
 
 const styles = { slackUrlBox, form, label, input, button };

--- a/frontend/src/components/host/SlackUrlModal/index.tsx
+++ b/frontend/src/components/host/SlackUrlModal/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 
 import Dimmer from '@/components/common/Dimmer';
-import Loading from '@/components/common/Loading';
+import LoadingOverlay from '@/components/common/LoadingOverlay';
 import SlackUrlBox from '@/components/host/SlackUrlBox';
 
 import { JobType } from '@/types';
@@ -23,14 +23,14 @@ const SlackUrlModal: React.FC<SlackUrlModalProps> = ({ jobs }) => {
         <div css={styles.container}>
           <div>
             <img css={styles.icon} src={slackIcon} alt="" />
-            <h1 css={styles.title}>Slack 알림 URL</h1>
+            <h1 css={styles.title}>Slack 알림</h1>
           </div>
-          <span css={styles.detail}>사용하시는 Slack 채널의 URL을 수정하세요.</span>
+          <span css={styles.detail}>Slack 채널의 URL을 입력하세요.</span>
           <div css={styles.contents}>
-            <Suspense fallback={<Loading />}>
+            <Suspense fallback={<LoadingOverlay />}>
               {jobs.length === 0 ? (
                 <div css={styles.noJobsInfo}>
-                  <span>생성된 업무가 없어요 😂</span>
+                  <span>생성한 업무가 없습니다.</span>
                 </div>
               ) : (
                 jobs.map((job, index) => <SlackUrlBox key={index} jobName={job.name} jobId={job.id} />)

--- a/frontend/src/components/host/SlackUrlModal/styles.ts
+++ b/frontend/src/components/host/SlackUrlModal/styles.ts
@@ -3,13 +3,14 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const container = css`
-  width: 560px;
+  max-width: 480px;
+  width: 80%;
   background-color: ${theme.colors.white};
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 40px 16px;
+  padding: 40px 24px;
   border-radius: 18px;
 
   div {
@@ -19,24 +20,26 @@ const container = css`
 
 const title = css`
   margin: 0;
+  font-size: 1.5rem;
 `;
 
 const detail = css`
   color: ${theme.colors.gray400};
-  margin: 16px 0;
+  margin: 24px 0;
+  font-size: 0.9rem;
 `;
 
 const icon = css`
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   margin-right: 12px;
 `;
 
 const contents = css`
   display: flex;
   flex-direction: column;
-  width: 80%;
-  height: 30vh;
+  width: 90%;
+  height: 24vh;
   overflow-y: scroll;
 
   ::-webkit-scrollbar {
@@ -68,7 +71,7 @@ const noJobsInfo = css`
   width: 100%;
   height: 100%;
 
-  font-size: 24px;
+  font-size: 18px;
   font-weight: 500;
 `;
 

--- a/frontend/src/components/host/SpaceDeleteButton/index.tsx
+++ b/frontend/src/components/host/SpaceDeleteButton/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { BiTrash } from 'react-icons/bi';
 import { useMutation, useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -56,7 +57,8 @@ const SpaceDeleteButton: React.FC<SpaceDeleteButtonProps> = ({ spaceId, spaceNam
 
   return (
     <Button css={styles.spaceDeleteButton} onClick={onClickDeleteSpace}>
-      공간 삭제
+      <BiTrash />
+      <span>공간 삭제</span>
     </Button>
   );
 };

--- a/frontend/src/components/host/SpaceDeleteButton/styles.ts
+++ b/frontend/src/components/host/SpaceDeleteButton/styles.ts
@@ -3,13 +3,33 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const spaceDeleteButton = css`
-  background-color: ${theme.colors.red};
   width: auto;
   height: 2rem;
-  font-weight: 500;
-  font-size: 1rem;
   padding: 0 12px;
-  margin: 0 0 24px 12px;
+  font-size: 0.9rem;
+  margin: 0 0 16px 12px;
+  background-color: ${theme.colors.red};
+  color: ${theme.colors.white};
+
+  svg {
+    height: 24px;
+    width: 24px;
+    transform: translateY(3px);
+  }
+
+  @media screen and (min-width: 1024px) {
+    svg {
+      height: 16px;
+      width: 16px;
+      margin-right: 4px;
+    }
+  }
+
+  @media screen and (max-width: 1023px) {
+    span {
+      display: none;
+    }
+  }
 `;
 
 const styles = { spaceDeleteButton };

--- a/frontend/src/components/host/SpaceDeleteModal/index.tsx
+++ b/frontend/src/components/host/SpaceDeleteModal/index.tsx
@@ -26,13 +26,14 @@ const SpaceDeleteModal: React.FC<SpaceDeleteModalProps> = ({ text, onClick }) =>
       <Dimmer>
         <div css={styles.container}>
           <div css={styles.textWrapper}>
-            <span>다음 내용을 입력하시면 공간을 삭제 할 수 있습니다.</span>
+            <span>다음 내용을 입력하시면, 공간을 삭제 할 수 있습니다.</span>
             <span>{text}</span>
           </div>
           <input css={styles.input} onChange={onChange} type="text" required />
           <Button css={styles.button(isDisabledButton)} onClick={onClick} disabled={isDisabledButton}>
-            삭제된 공간은 복구되지 않습니다.
+            삭제
           </Button>
+          <span css={styles.alert}>※ 한번 삭제된 공간은 복구되지 않습니다.</span>
         </div>
       </Dimmer>
     </ModalPortal>

--- a/frontend/src/components/host/SpaceDeleteModal/styles.ts
+++ b/frontend/src/components/host/SpaceDeleteModal/styles.ts
@@ -5,13 +5,14 @@ import theme from '@/styles/theme';
 const layout = css``;
 
 const container = css`
-  width: 480px;
+  max-width: 480px;
+  width: 80%;
   background-color: ${theme.colors.white};
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 2rem 2.5rem;
+  padding: 2rem;
   border-radius: 18px;
 
   div {
@@ -21,12 +22,12 @@ const container = css`
 
 const input = css`
   width: 100%;
-  height: 3rem;
+  height: 2rem;
   border-radius: 12px;
   font-size: 1rem;
   font-weight: 600;
   border: 1px ${theme.colors.gray300} solid;
-  padding: 24px;
+  padding: 16px;
 
   &:focus {
     outline: none;
@@ -35,24 +36,33 @@ const input = css`
 
 const button = (isDisabledButton: boolean) => css`
   width: 100%;
-  height: 3rem;
+  height: 2.4rem;
   background: ${isDisabledButton ? theme.colors.gray400 : theme.colors.red};
+  margin: 16px 0;
 `;
 
 const textWrapper = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.8rem;
+  font-size: 0.9rem;
+  color: ${theme.colors.gray500};
   span {
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.8rem;
   }
   & > span:nth-last-of-type(1) {
     color: ${theme.colors.red};
+    font-size: 1.1rem;
     font-weight: 600;
   }
 `;
 
-const styles = { layout, container, input, button, textWrapper };
+const alert = css`
+  font-size: 0.8rem;
+  color: ${theme.colors.gray500};
+`;
+
+const styles = { layout, container, input, button, textWrapper, alert };
 
 export default styles;

--- a/frontend/src/components/host/SpaceInfo/styles.ts
+++ b/frontend/src/components/host/SpaceInfo/styles.ts
@@ -3,35 +3,39 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const contentWith = css`
-  width: 80%;
-  margin: 0 auto;
+  padding: 0 24px;
 `;
 
 const spaceInfo = css`
-  height: 100%;
-  min-height: 28rem;
-  min-width: 21rem;
-  background: ${theme.colors.white};
+  min-width: 320px;
+  height: 452px;
+  background-color: ${theme.colors.white};
   border-radius: 8px;
   box-shadow: 2px 2px 2px 2px ${theme.colors.shadow10};
+
+  @media screen and (min-width: 1024px) {
+    width: 320px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    width: 90%;
+  }
 `;
 
 const titleWrapper = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 1.25rem;
+  padding: 0 24px;
   border-bottom: 1px solid ${theme.colors.gray300};
 `;
 
 const title = css`
-  margin: 19px;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
 `;
 
 const subTitle = css`
-  font-size: 1rem;
-  font-weight: bold;
+  font-size: 0.8rem;
 `;
 
 const imageContainer = css`
@@ -58,7 +62,7 @@ const inputWrapper = css`
 
 const nameText = css`
   border: none;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: bold;
   width: 100%;
   margin: 0;

--- a/frontend/src/components/host/SpaceInfoCreateBox/index.tsx
+++ b/frontend/src/components/host/SpaceInfoCreateBox/index.tsx
@@ -15,7 +15,7 @@ const SpaceInfoCreateBox: React.FC = () => {
 
   return (
     <>
-      <form onSubmit={e => onSubmitCreateSpace(e, imageUrl)} encType="multipart/form-data">
+      <form css={styles.form} onSubmit={e => onSubmitCreateSpace(e, imageUrl)} encType="multipart/form-data">
         <SpaceInfo>
           <SpaceInfo.header>
             <Button type="submit" css={styles.button({ isActive: isActiveSubmit })}>

--- a/frontend/src/components/host/SpaceInfoCreateBox/styles.ts
+++ b/frontend/src/components/host/SpaceInfoCreateBox/styles.ts
@@ -2,18 +2,18 @@ import { css } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
-const button = ({ isActive }: { isActive?: boolean }) => css`
-  width: 5rem;
-  height: 2rem;
+const form = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 320px;
+  padding: 0;
   margin: 0;
-  font-size: 1rem;
-  padding: 8px 0;
-  background: ${isActive ? theme.colors.primary : theme.colors.gray400};
 `;
 
 const input = css`
   border: none;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: bold;
   cursor: pointer;
 
@@ -23,9 +23,18 @@ const input = css`
   }
 `;
 
+const button = ({ isActive }: { isActive?: boolean }) => css`
+  width: 5rem;
+  height: 2rem;
+  margin: 0;
+  font-size: 0.9rem;
+  background: ${isActive ? theme.colors.primary : theme.colors.gray400};
+`;
+
 const styles = {
-  button,
+  form,
   input,
+  button,
 };
 
 export default styles;

--- a/frontend/src/components/host/SpaceInfoDisplayBox/styles.ts
+++ b/frontend/src/components/host/SpaceInfoDisplayBox/styles.ts
@@ -6,17 +6,15 @@ const button = css`
   width: 5rem;
   height: 2rem;
   margin: 0;
-  font-size: 1rem;
-  padding: 8px 0;
+  font-size: 0.9rem;
   background: ${theme.colors.primary};
 `;
 
 const input = css`
   border: none;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: bold;
   cursor: pointer;
-
   width: 100%;
   &:focus {
     outline: none;

--- a/frontend/src/components/host/SpaceInfoUpdateBox/index.tsx
+++ b/frontend/src/components/host/SpaceInfoUpdateBox/index.tsx
@@ -1,4 +1,5 @@
 import useSpaceUpdateForm from './useSpaceUpdateForm';
+import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
 import LoadingOverlay from '@/components/common/LoadingOverlay';
@@ -22,7 +23,7 @@ const SpaceInfoUpdateBox: React.FC<SpaceInfoUpdateBox> = ({ spaceData, spaceId }
 
   return (
     <>
-      <form onSubmit={e => onSubmitUpdateSpace(e, imageUrl, spaceId)} encType="multipart/form-data">
+      <form css={styles.form} onSubmit={e => onSubmitUpdateSpace(e, imageUrl, spaceId)} encType="multipart/form-data">
         <SpaceInfo>
           <SpaceInfo.header>
             <Button type="submit" css={styles.button({ isActive: isActiveSubmit })}>

--- a/frontend/src/components/host/SpaceInfoUpdateBox/index.tsx
+++ b/frontend/src/components/host/SpaceInfoUpdateBox/index.tsx
@@ -1,5 +1,4 @@
 import useSpaceUpdateForm from './useSpaceUpdateForm';
-import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
 import LoadingOverlay from '@/components/common/LoadingOverlay';

--- a/frontend/src/components/host/SpaceInfoUpdateBox/styles.ts
+++ b/frontend/src/components/host/SpaceInfoUpdateBox/styles.ts
@@ -2,9 +2,18 @@ import { css } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
+const form = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 320px;
+  padding: 0;
+  margin: 0;
+`;
+
 const input = css`
   border: none;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: bold;
   cursor: pointer;
 
@@ -18,11 +27,10 @@ const button = ({ isActive }: { isActive?: boolean }) => css`
   width: 5rem;
   height: 2rem;
   margin: 0;
-  font-size: 1rem;
-  padding: 8px 0;
+  font-size: 0.9rem;
   background: ${isActive ? theme.colors.primary : theme.colors.gray400};
 `;
 
-const styles = { input, button };
+const styles = { form, input, button };
 
 export default styles;

--- a/frontend/src/components/host/Submissions/index.tsx
+++ b/frontend/src/components/host/Submissions/index.tsx
@@ -1,12 +1,8 @@
-import { css } from '@emotion/react';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button';
 
 import emptyFolder from '@/assets/emptyFolder.png';
-
-import theme from '@/styles/theme';
 
 import styles from './styles';
 
@@ -25,6 +21,18 @@ interface SubmissionsProps {
   isFullSize?: boolean;
 }
 
+function formatDate(targetDate: string) {
+  const date = new Date(targetDate);
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  return `${year}년 ${month}월 ${day}일 ${hours}시 ${minutes}분`;
+}
+
 const Submissions: React.FC<SubmissionsProps> = ({ submissions, isFullSize = false }) => {
   const navigate = useNavigate();
 
@@ -35,7 +43,7 @@ const Submissions: React.FC<SubmissionsProps> = ({ submissions, isFullSize = fal
   return (
     <div css={styles.layout({ isFullSize })}>
       <div css={styles.header}>
-        <p>공간 사용 내역</p>
+        <p>사용 내역</p>
 
         {!isFullSize && (
           <Button css={styles.detailButton} type="button" onClick={onClickSubmissionsDetail}>
@@ -54,24 +62,13 @@ const Submissions: React.FC<SubmissionsProps> = ({ submissions, isFullSize = fal
           </thead>
 
           <tbody>
-            {submissions.length === 0 ? (
-              <tr css={styles.empty}>
-                <td>
-                  <img src={emptyFolder} alt="" />
-                  <div>제출된 내역이 없어요.</div>
-                </td>
+            {submissions.map(({ submissionId, author, jobName, createdAt }) => (
+              <tr key={submissionId}>
+                <td>{author}</td>
+                <td>{jobName}</td>
+                <td css={styles.greenText}>{formatDate(createdAt)}</td>
               </tr>
-            ) : (
-              <>
-                {submissions.map(({ submissionId, author, jobName, createdAt }) => (
-                  <tr key={submissionId}>
-                    <td>{author}</td>
-                    <td>{jobName}</td>
-                    <td css={styles.greenText}>{createdAt}</td>
-                  </tr>
-                ))}
-              </>
-            )}
+            ))}
           </tbody>
         </table>
       </div>

--- a/frontend/src/components/host/Submissions/styles.ts
+++ b/frontend/src/components/host/Submissions/styles.ts
@@ -3,24 +3,36 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const layout = ({ isFullSize }: { isFullSize: boolean }) => css`
-  background: ${theme.colors.white};
+  min-width: 320px;
+  background-color: ${theme.colors.white};
   border-radius: 8px;
   font-size: 16px;
   box-shadow: 2px 2px 2px 2px ${theme.colors.shadow10};
+  height: 360px;
+
   ${isFullSize &&
   css`
     margin-top: 5rem;
+    height: 480px;
   `}
+
+  @media screen and (min-width: 1024px) {
+    width: 100%;
+  }
+
+  @media screen and (max-width: 1023px) {
+    width: 90%;
+  }
 `;
 
 const header = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 1.25em;
-
+  padding: 0 24px;
+  border-bottom: 1px solid ${theme.colors.gray300};
   p {
-    font-size: 1.3em;
+    font-size: 1.2rem;
   }
 `;
 
@@ -28,8 +40,7 @@ const detailButton = css`
   width: 5rem;
   height: 2rem;
   margin: 0;
-  font-size: 1rem;
-  padding: 8px 0;
+  font-size: 0.9rem;
 `;
 
 const table = ({ isFullSize }: { isFullSize: boolean }) => css`
@@ -50,6 +61,7 @@ const table = ({ isFullSize }: { isFullSize: boolean }) => css`
     display: flex;
     flex-direction: column;
     justify-content: start;
+    height: 100%;
     width: 100%;
     overflow-y: ${isFullSize ? 'scroll' : 'hidden'};
     height: ${isFullSize ? '50vh' : '12.5em'};
@@ -88,36 +100,14 @@ const table = ({ isFullSize }: { isFullSize: boolean }) => css`
   td {
     padding: 1em;
     height: 10px;
-    width: 28vw;
-    min-width: 160px;
+    width: 20vw;
+    min-width: 80px;
     word-wrap: break-word;
     text-align: left;
     &:nth-of-type(3) {
-      width: 60vw;
-      min-width: 320px;
+      width: 30vw;
+      min-width: 160px;
     }
-  }
-`;
-
-const empty = css`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  td {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  }
-
-  img {
-    max-width: 100px;
-    margin-bottom: 12px;
   }
 `;
 
@@ -125,6 +115,6 @@ const greenText = css`
   color: ${theme.colors.green};
 `;
 
-const styles = { layout, header, detailButton, table, empty, greenText };
+const styles = { layout, header, detailButton, table, greenText };
 
 export default styles;

--- a/frontend/src/components/host/TaskBox/index.tsx
+++ b/frontend/src/components/host/TaskBox/index.tsx
@@ -1,5 +1,5 @@
 import useTaskBox from './useTaskBox';
-import { BiMinus, BiNews, BiXCircle } from 'react-icons/bi';
+import { BiMinus, BiNews } from 'react-icons/bi';
 
 import { TaskType } from '@/types';
 

--- a/frontend/src/layouts/HostLayout/styles.ts
+++ b/frontend/src/layouts/HostLayout/styles.ts
@@ -8,14 +8,19 @@ const layout = (isManagePath: boolean) => css`
   width: 100vw;
   min-height: 100vh;
   height: fit-content;
-  background-color: ${theme.colors.white};
-  padding-left: ${isManagePath ? '14em' : 0};
+  background-color: ${theme.colors.background};
 
-  @media screen and (max-width: 1024px) {
-    font-size: 14px;
-  }
   @media screen and (max-width: 720px) {
     font-size: 12px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    font-size: 14px;
+    padding-top: ${isManagePath ? '64px' : 0};
+  }
+
+  @media screen and (min-width: 1024px) {
+    padding-left: ${isManagePath ? '14em' : 0};
   }
 `;
 

--- a/frontend/src/layouts/ManageLayout/index.tsx
+++ b/frontend/src/layouts/ManageLayout/index.tsx
@@ -1,11 +1,34 @@
+import isNull from '@/utils/isNull';
+import { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import Navigation from '@/components/host/Navigation';
+import LeftNavigator from '@/components/host/Navigator/LeftNavigator';
+import TopNavigator from '@/components/host/Navigator/TopNavigator';
 
 const ManageLayout = () => {
+  const [isDeskTop, setIsDeskTop] = useState<boolean | null>(null);
+
+  const resizeHandler = () => {
+    if (innerWidth >= 1024) {
+      setIsDeskTop(true);
+      return;
+    }
+    setIsDeskTop(false);
+  };
+
+  useEffect(() => {
+    resizeHandler();
+
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      window.removeEventListener('resize', resizeHandler);
+    };
+  }, []);
+
   return (
     <>
-      <Navigation />
+      {!isNull(isDeskTop) && (isDeskTop ? <LeftNavigator /> : <TopNavigator />)}
       <Outlet />
     </>
   );

--- a/frontend/src/pages/host/DashBoard/index.tsx
+++ b/frontend/src/pages/host/DashBoard/index.tsx
@@ -23,7 +23,7 @@ const DashBoard: React.FC = () => {
             <span>입장 링크 복사</span>
           </Button>
           <Button css={styles.slackButton} onClick={onClickSlackButton}>
-            <img src={slackIcon} alt="슬랙" />
+            <img src={slackIcon} alt="슬랙 URL 편집" />
             <span>URL 편집</span>
           </Button>
           <SpaceDeleteButton spaceId={spaceId} spaceName={spaceData?.name || ''} />

--- a/frontend/src/pages/host/DashBoard/styles.ts
+++ b/frontend/src/pages/host/DashBoard/styles.ts
@@ -3,9 +3,16 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const layout = css`
-  padding: 32px 48px;
   display: flex;
   flex-direction: column;
+
+  @media screen and (min-width: 1024px) {
+    padding: 32px 48px;
+  }
+
+  @media screen and (max-width: 1023px) {
+    padding: 16px;
+  }
 `;
 
 const contents = css`
@@ -19,27 +26,49 @@ const contents = css`
 const cardWrapper = css`
   display: flex;
   width: 100%;
-  justify-content: space-around;
   gap: 20px;
-  margin-bottom: 32px;
+  margin-bottom: 20px;
+
+  @media screen and (min-width: 1024px) {
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
+  @media screen and (max-width: 1023px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 `;
 
 const linkButton = css`
   width: auto;
   height: 2rem;
   padding: 0 12px;
-  font-weight: 500;
-  font-size: 1rem;
+  font-size: 0.9rem;
   margin: 0 0 16px 12px;
   background-color: ${theme.colors.green};
   color: ${theme.colors.white};
   box-shadow: 0px 0px 1px 1px ${theme.colors.shadow10};
 
   svg {
-    height: 14px;
-    width: 14px;
-    margin-right: 6px;
-    transform: translateY(2px);
+    height: 20px;
+    width: 20px;
+    transform: translateY(3px);
+  }
+
+  @media screen and (min-width: 1024px) {
+    svg {
+      height: 16px;
+      width: 16px;
+      margin-right: 4px;
+    }
+  }
+
+  @media screen and (max-width: 1023px) {
+    span {
+      display: none;
+    }
   }
 `;
 
@@ -47,25 +76,44 @@ const slackButton = css`
   width: auto;
   height: 2rem;
   padding: 0 12px;
-  font-weight: 500;
-  font-size: 1rem;
+  font-size: 0.9rem;
   margin: 0 0 16px 12px;
   background-color: ${theme.colors.white};
   color: ${theme.colors.black};
   box-shadow: 0px 0px 1px 1px ${theme.colors.shadow30};
 
   img {
-    height: 14px;
-    width: 14px;
-    margin-right: 6px;
+    height: 18px;
+    width: 18px;
     transform: translateY(2px);
+  }
+
+  @media screen and (min-width: 1024px) {
+    img {
+      height: 14px;
+      width: 14px;
+      margin-right: 6px;
+    }
+  }
+
+  @media screen and (max-width: 1023px) {
+    span {
+      display: none;
+    }
   }
 `;
 
 const buttons = css`
-  width: 100%;
   display: flex;
   justify-content: end;
+
+  @media screen and (min-width: 1024px) {
+    width: 100%;
+  }
+
+  @media screen and (max-width: 1023px) {
+    width: 90%;
+  }
 `;
 
 const styles = { layout, contents, cardWrapper, slackButton, linkButton, buttons };

--- a/frontend/src/pages/host/DashBoard/useDashBoard.tsx
+++ b/frontend/src/pages/host/DashBoard/useDashBoard.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import SlackUrlModal from '@/components/host/SlackUrlModal';
 
@@ -14,8 +14,6 @@ import apiSubmission from '@/apis/submission';
 import { ID } from '@/types';
 
 const useDashBoard = () => {
-  const navigate = useNavigate();
-
   const { openModal } = useModal();
   const { openToast } = useToast();
 
@@ -31,8 +29,14 @@ const useDashBoard = () => {
     suspense: false,
     enabled: false,
     onSuccess: data => {
-      navigator.clipboard.writeText(`${location.origin}/enter/${data.entranceCode}/pwd`);
-      openToast('SUCCESS', '공간 입장 링크가 복사되었습니다.');
+      navigator.clipboard
+        .writeText(`${location.origin}/enter/${data.entranceCode}/pwd`)
+        .then(() => {
+          openToast('SUCCESS', '공간 입장 링크가 복사되었습니다.');
+        })
+        .catch(() => {
+          openToast('ERROR', '다시 시도해주세요.');
+        });
     },
     onError: () => {
       openToast('ERROR', '잠시 후 다시 시도해주세요.');

--- a/frontend/src/pages/host/Home/index.tsx
+++ b/frontend/src/pages/host/Home/index.tsx
@@ -1,79 +1,18 @@
-import { css } from '@emotion/react';
-
 import GitHubLoginButton from '@/components/common/GitHubLoginButton';
 
 import homeCover from '@/assets/homeCover.png';
 import logoTitle from '@/assets/logoTitle.png';
 
-import theme from '@/styles/theme';
+import styles from './styles';
 
 const Home: React.FC = () => {
-  const isMobile = innerWidth < 600;
-
   return (
     <>
-      <div
-        id="헤더"
-        css={css`
-          display: flex;
-          align-items: center;
-          width: 100vw;
-          height: 84px;
-          padding: 0 48px;
-          font-size: 24px;
-          font-weight: 600;
-          background-color: ${theme.colors.skyblue200};
-          box-shadow: 0px 2px 1px 1px ${theme.colors.shadow20};
-
-          img {
-            margin-right: 10px;
-          }
-
-          span > b {
-            font-size: 16px;
-          }
-        `}
-      >
-        <img src={logoTitle} alt="" width={240} />
-        {!isMobile && (
-          <span>
-            <b>for</b> 공간 관리자
-          </span>
-        )}
+      <div css={styles.header}>
+        <img src={logoTitle} alt="공책" />
       </div>
-      <div
-        id="레이아웃"
-        css={css`
-          display: flex;
-          height: calc(100vh - 84px);
-          flex-direction: column;
-          align-items: center;
-
-          img {
-            margin-top: 32px;
-          }
-        `}
-      >
-        {isMobile && (
-          <div
-            css={css`
-              margin: 20px;
-              color: ${theme.colors.red};
-            `}
-          >
-            모바일에 최적화되어있지 않습니다. 데스크탑을 이용해주세요.
-          </div>
-        )}
-        <img src={homeCover} alt="" width={360} />
-        <span
-          css={css`
-            margin: 32px 0 62px 0;
-            color: ${theme.colors.gray800};
-            font-size: ${isMobile ? '16px' : '24px'};
-          `}
-        >
-          관리자 페이지 이용을 위해 로그인이 필요합니다.
-        </span>
+      <div css={styles.layout}>
+        <img src={homeCover} alt="함께 사용하는 우리의 공간 우리가 체크하자, 공책" />
         <GitHubLoginButton />
       </div>
     </>

--- a/frontend/src/pages/host/Home/styles.ts
+++ b/frontend/src/pages/host/Home/styles.ts
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const header = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 64px;
+  background-color: ${theme.colors.white};
+  box-shadow: 0px 2px 2px 2px ${theme.colors.shadow20};
+
+  img {
+    height: 40px;
+    transform: translateY(4px);
+  }
+`;
+
+const layout = css`
+  display: flex;
+  padding: 48px 0 64px 0;
+  height: calc(100vh - 64px);
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+
+  img {
+    width: 80%;
+    max-width: 420px;
+  }
+`;
+
+const styles = { header, layout };
+
+export default styles;

--- a/frontend/src/pages/host/JobCreate/styles.ts
+++ b/frontend/src/pages/host/JobCreate/styles.ts
@@ -11,10 +11,10 @@ const layout = css`
 `;
 
 const contents = css`
-  width: 95%;
+  width: 100%;
   min-height: 100%;
   background-color: ${theme.colors.white};
-  min-width: 360px;
+  min-width: 356px;
 `;
 
 const grid = css`
@@ -33,7 +33,7 @@ const createCard = css`
   align-items: center;
   width: 100%;
   max-width: 480px;
-  height: 360px;
+  height: 356px;
   background-color: ${theme.colors.gray200};
   font-size: 64px;
   border-radius: 8px;
@@ -43,26 +43,6 @@ const createCard = css`
   }
 `;
 
-const createButton = css`
-  background-color: ${theme.colors.green};
-`;
-
-const jobNameInput = css`
-  border: none;
-  border-radius: 12px;
-  width: 50%;
-  height: 48px;
-  padding: 8px 16px;
-  font-size: 28px;
-  font-weight: 500;
-  margin: 12px 0;
-  background-color: ${theme.colors.shadow20};
-
-  :focus {
-    outline: 2px solid ${theme.colors.shadow30};
-  }
-`;
-
-const styles = { layout, contents, grid, createCard, createButton, jobNameInput };
+const styles = { layout, contents, grid, createCard };
 
 export default styles;

--- a/frontend/src/pages/host/JobUpdate/index.tsx
+++ b/frontend/src/pages/host/JobUpdate/index.tsx
@@ -3,8 +3,6 @@ import useJobUpdate from './useJobUpdate';
 import JobControl from '@/components/host/JobControl';
 import SectionCard from '@/components/host/SectionCard';
 
-import useSections from '@/hooks/useSections';
-
 import styles from './styles';
 
 const JobUpdate: React.FC = () => {

--- a/frontend/src/pages/host/JobUpdate/styles.ts
+++ b/frontend/src/pages/host/JobUpdate/styles.ts
@@ -14,7 +14,7 @@ const contents = css`
   width: 95%;
   min-height: 100%;
   background-color: ${theme.colors.white};
-  min-width: 360px;
+  min-width: 356px;
 `;
 
 const grid = css`
@@ -33,7 +33,7 @@ const createCard = css`
   align-items: center;
   width: 100%;
   max-width: 480px;
-  height: 360px;
+  height: 356px;
   background-color: ${theme.colors.gray200};
   font-size: 64px;
   border-radius: 8px;
@@ -43,26 +43,6 @@ const createCard = css`
   }
 `;
 
-const createButton = css`
-  background-color: ${theme.colors.green};
-`;
-
-const jobNameInput = css`
-  border: none;
-  border-radius: 12px;
-  width: 50%;
-  height: 48px;
-  padding: 8px 16px;
-  font-size: 28px;
-  font-weight: 500;
-  margin: 12px 0;
-  background-color: ${theme.colors.shadow20};
-
-  :focus {
-    outline: 2px solid ${theme.colors.shadow30};
-  }
-`;
-
-const styles = { layout, contents, grid, createCard, createButton, jobNameInput };
+const styles = { layout, contents, grid, createCard };
 
 export default styles;

--- a/frontend/src/pages/host/PasswordUpdate/styles.ts
+++ b/frontend/src/pages/host/PasswordUpdate/styles.ts
@@ -12,7 +12,7 @@ const layout = css`
 
   svg + span {
     color: ${theme.colors.shadow50};
-    font-size: 24px;
+    font-size: 16px;
     margin: 24px 0 32px 0;
   }
   svg {
@@ -28,12 +28,12 @@ const content = css`
 
 const inputWrapper = css`
   width: 280px;
-  height: 48px;
+  height: 36px;
   display: flex;
   justify-content: space-around;
   align-items: center;
   background-color: ${theme.colors.gray200};
-  border: 2px solid ${theme.colors.gray400};
+  border: 1px solid ${theme.colors.gray400};
   border-radius: 8px;
   padding: 0 12px;
 
@@ -43,7 +43,7 @@ const inputWrapper = css`
     background-color: ${theme.colors.gray200};
     border: none;
     outline: none;
-    font-size: 20px;
+    font-size: 16px;
     color: ${theme.colors.shadow80};
   }
 
@@ -60,6 +60,7 @@ const inputWrapper = css`
 const button = css`
   margin: 0 0 0 8px;
   width: auto;
+  height: 36px;
   padding: 0 16px;
 `;
 

--- a/frontend/src/pages/host/SpaceCreate/styles.ts
+++ b/frontend/src/pages/host/SpaceCreate/styles.ts
@@ -2,25 +2,11 @@ import { css } from '@emotion/react';
 
 const layout = css`
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 64px);
   display: flex;
   justify-content: center;
-  align-items: center;
 `;
 
-const contents = css`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
-
-const text = css`
-  font-size: 2rem;
-  font-weight: bold;
-  margin: 0;
-`;
-
-const styles = { layout, contents, text };
+const styles = { layout };
 
 export default styles;

--- a/frontend/src/pages/host/SpaceUpdate/styles.ts
+++ b/frontend/src/pages/host/SpaceUpdate/styles.ts
@@ -2,10 +2,9 @@ import { css } from '@emotion/react';
 
 const layout = css`
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 64px);
   display: flex;
   justify-content: center;
-  align-items: center;
 `;
 
 const styles = { layout };

--- a/frontend/src/styles/animation.ts
+++ b/frontend/src/styles/animation.ts
@@ -158,6 +158,24 @@ const wave = keyframes`
     transform: skew(2deg, 2deg);
   }`;
 
+const navigatorOpen = keyframes`
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0)
+  }
+`;
+
+const navigatorClose = keyframes`
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%)
+  }
+`;
+
 const animation = {
   fadeIn,
   fadeOut,
@@ -173,6 +191,8 @@ const animation = {
   wave,
   scaleUp,
   scaleDown,
+  navigatorOpen,
+  navigatorClose,
 };
 
 export default animation;

--- a/frontend/src/utils/isNull.ts
+++ b/frontend/src/utils/isNull.ts
@@ -1,0 +1,5 @@
+const isNull = (target: any) => {
+  return target === null;
+};
+
+export default isNull;


### PR DESCRIPTION
## issue
- resolve #292 

## 코드 설명
- 관리자 페이지 모바일 화면을 제공할 수 있도록 하였습니다.
- 1024px 기준으로 데스크탑을 나누었습니다.
- 전체적인 폰트 사이즈를 줄였습니다.
- 세부적인 디자인 및 문구를 수정하였습니다.
<img width="376" alt="스크린샷 2022-09-15 11 08 27" src="https://user-images.githubusercontent.com/62434898/190299080-055508ba-f739-44c7-88de-392a391c8745.png">

<img width="376" alt="스크린샷 2022-09-15 11 08 32" src="https://user-images.githubusercontent.com/62434898/190299076-5e4803db-f924-4efb-b6a4-fb7d75ce4433.png">


