### PR TITLE
[BE] N+1 발생하는 지점 파악 후 해결한다. 

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/core/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/application/TaskService.java
@@ -19,6 +19,7 @@ import com.woowacourse.gongcheck.core.domain.task.Tasks;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.ErrorCode;
 import com.woowacourse.gongcheck.exception.NotFoundException;
+import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -75,14 +76,13 @@ public class TaskService {
     public void flipRunningTask(final Long hostId, final Long taskId) {
         Host host = hostRepository.getById(hostId);
         Task task = taskRepository.getBySectionJobSpaceHostAndId(host, taskId);
-        RunningTask runningTask = runningTaskRepository.findByTaskId(task.getId())
-                .orElseThrow(() -> {
-                    String message = String.format("현재 진행 중인 작업이 아닙니다. hostId = %d, taskId = %d", hostId, taskId);
-                    throw new BusinessException(message, ErrorCode.R002);
-                });
+        RunningTask runningTask = task.getRunningTask();
+        if (Objects.isNull(runningTask)) {
+            String message = String.format("현재 진행 중인 작업이 아닙니다. hostId = %d, taskId = %d", hostId, taskId);
+            throw new BusinessException(message, ErrorCode.R002);
+        }
 
         runningTask.flipCheckedStatus();
-
         Long jobId = task.getSection().getJob().getId();
         RunningTasksResponse runningTasks = findExistingRunningTasks(hostId, jobId);
 

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/application/TaskService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/application/TaskService.java
@@ -19,7 +19,6 @@ import com.woowacourse.gongcheck.core.domain.task.Tasks;
 import com.woowacourse.gongcheck.exception.BusinessException;
 import com.woowacourse.gongcheck.exception.ErrorCode;
 import com.woowacourse.gongcheck.exception.NotFoundException;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -77,7 +76,7 @@ public class TaskService {
         Host host = hostRepository.getById(hostId);
         Task task = taskRepository.getBySectionJobSpaceHostAndId(host, taskId);
         RunningTask runningTask = task.getRunningTask();
-        if (Objects.isNull(runningTask)) {
+        if (runningTask == null) {
             String message = String.format("현재 진행 중인 작업이 아닙니다. hostId = %d, taskId = %d", hostId, taskId);
             throw new BusinessException(message, ErrorCode.R002);
         }

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/domain/task/TaskRepository.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/domain/task/TaskRepository.java
@@ -10,15 +10,18 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
-    @EntityGraph(attributePaths = {"runningTask"}, type = EntityGraphType.FETCH)
-    List<Task> findAllBySectionJob(final Job job);
+    @Query("select t from Task t left join fetch t.runningTask join fetch t.section s join fetch s.job j where j = :job")
+    List<Task> findAllBySectionJob(@Param("job") final Job job);
 
     Optional<Task> findBySectionJobSpaceHostAndId(final Host host, final Long id);
 
-    List<Task> findAllBySectionIn(final List<Section> sections);
+    @Query("select t from Task t left join fetch t.runningTask where t.section in (:sections)")
+    List<Task> findAllBySectionIn(@Param("sections") final List<Section> sections);
 
     void deleteAllBySectionIn(final List<Section> sections);
 


### PR DESCRIPTION
## issue
- resolve #553 

## 코드 설명
**1. Task-Running_Task 조회 시 문제.**
Task과 Running_task의 연관관계는 OneToOne입니다.
따라서 Task를 조회할 때, Running_Task를 함께 조회해 오지 않는다면, Task의 개수 만큼 조회 쿼리가 발생하게 됩니다.
(ex. 100개의 Task를 조회하는 쿼리 1개 발생 시, 100개의 Running_Task 조회 쿼리가 발생합니다.)
이를 Task 조회 시, Running_Task도 함께 fetch join을 사용하여 한 번에 조회하게 수정했습니다.


**2. Task 조회 시, Section 지연 로딩 문제**
전형적인 n+1 문제 발생 상황입니다.
Task 리스트를 조회하여 DTO로 변환 시, Task의 Section을 필요로 하기 때문에
조회한 Task 개수 n만큼의 조회 쿼리가 추가적으로 발생하게 됩니다.
따라서 해당 메서드는 Task조회 시, fetch join을 사용하여 Section도 한 번에 조회하게 수정했습니다.


자세한 내용은 [링크](https://meatsby.notion.site/N-1-1d0e66ca615b409dbc7380e856bb541e)로 정리했으니, 참고해 보시면 좋을 것 같습니다.

