### PR TITLE
[FE] font preload를 해야 한다.

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="kagR4K5UE3D8eryyAxhnW3Jf5jVLBe2yl9nU_Tr8Kuk" />
+    <link
+      rel="preload"
+      href="https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <title>Gong Check</title>
   </head>
   <body>

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -7,11 +7,12 @@ const globalStyle = css`
     src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff') format('woff');
     font-weight: 0;
     font-style: normal;
+    font-display: swap;
   }
 
   * {
     box-sizing: border-box;
-    font-family: '지마켓';
+    font-family: '지마켓', 'Noto Sans Korean', 'Roboto';
   }
 
   a {


### PR DESCRIPTION
## issue
- resolve #572 

## 코드 설명
- index.html에 link 태그로 font preload 설정
- font-display: swap 설정

## 참고 
- [WebFont 로딩 및 렌더링 최적화](https://web.dev/i18n/ko/optimize-webfont-loading/)
- [웹 폰트 로딩을 더 빠르게 하는 방법](https://yceffort.kr/2021/06/ways-to-faster-web-fonts)
- [웹 글꼴을 미리 로드하여 로딩 속도 개선](https://web.dev/codelab-preload-web-fonts/)