### PR TITLE
[FE] 사용자 페이지를 찾을 수 없어서 Cypress 오류가 뜨던 현상 해결

### DIFF
--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -6,6 +6,7 @@ const Dotenv = require('dotenv-webpack');
 module.exports = merge(common, {
   mode: 'development',
   output: {
+    publicPath: '/',
     filename: 'js/bundle.js',
     path: path.join(__dirname, '/dist'),
     clean: true,


### PR DESCRIPTION
```js
 output: {
    publicPath: '/',
    filename: 'js/bundle.js',
    path: path.join(__dirname, '/dist'),
    clean: true,
  },
```

publicPath 추가

output.publicPath
번들 파일을 업로드 한 위치 (서버 루트에 상대적)

웹팩에서 발생하는 모든 URL이 publicPath 로 시작하도록 다시 작성
