### PR TITLE
[BE] Mysql TestContainer 테스트 환경을 구성한다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,11 @@ dependencies {
     implementation 'com.slack.api:slack-app-backend:1.22.2'
     implementation 'com.slack.api:slack-api-model:1.22.2'
     implementation "com.github.maricn:logback-slack-appender:1.6.1"
+
+    //testcontainers
+    implementation "org.testcontainers:testcontainers:1.17.3"
+    implementation "org.testcontainers:junit-jupiter:1.17.3"
+    implementation "org.testcontainers:mysql:1.17.3"
 }
 
 processResources.dependsOn('copySecret')
@@ -109,8 +114,8 @@ task createDocument(type: Copy) {
 task displaceDocument(type: Copy) {
     dependsOn asciidoctor
 
-    from ("${asciidoctor.outputDir}")
-    into ("build/resources/main/static")
+    from("${asciidoctor.outputDir}")
+    into("build/resources/main/static")
 }
 
 bootJar {

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -3,10 +3,10 @@ spring:
     init:
       schema-locations: classpath:schema_local.sql
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:gong-check-test;MODE=MYSQL;
-    username: sa
-    password:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8.0.30:///gongcheck?TC_INITSCRIPT=schema.sql
+    username: root
+    password: password
   h2:
     console:
       enabled: true

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/DatabaseInitializer.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/DatabaseInitializer.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DatabaseInitializer {
 
     private static final String TRUNCATE_QUERY = "TRUNCATE TABLE %s";
-    private static final String ALTER_COLUMN_QUERY = "ALTER TABLE %s ALTER COLUMN id RESTART WITH 1";
+    private static final String ALTER_COLUMN_QUERY = "ALTER TABLE %s AUTO_INCREMENT = 1";
 
     @Autowired
     private EntityManager entityManager;
@@ -41,11 +41,11 @@ public class DatabaseInitializer {
 
     @Transactional
     public void truncateTables() {
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
         for (String tableName : tableNames) {
             truncateTable(tableName);
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
     }
 
     @Transactional

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -1,43 +1,46 @@
-DROP TABLE host IF EXISTS;
-DROP TABLE space IF EXISTS;
-DROP TABLE job IF EXISTS;
-DROP TABLE running_task IF EXISTS;
-DROP TABLE task IF EXISTS;
-DROP TABLE section IF EXISTS;
-DROP TABLE submission IF EXISTS;
+DROP TABLE IF EXISTS host;
+DROP TABLE IF EXISTS space;
+DROP TABLE IF EXISTS job;
+DROP TABLE IF EXISTS running_task;
+DROP TABLE IF EXISTS task;
+DROP TABLE IF EXISTS section;
+DROP TABLE IF EXISTS submission;
 
 CREATE TABLE host
 (
-    id             BIGINT     NOT NULL AUTO_INCREMENT,
-    space_password VARCHAR(4) NOT NULL,
-    github_id      BIGINT     NOT NULL UNIQUE,
-    image_url      VARCHAR    NOT NULL,
-    created_at     TIMESTAMP  NOT NULL,
-    updated_at     TIMESTAMP  NULL,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    space_password VARCHAR(4)   NOT NULL,
+    github_id      BIGINT       NOT NULL UNIQUE,
+    image_url      VARCHAR(255) NOT NULL,
+    created_at     TIMESTAMP    NOT NULL,
+    updated_at     TIMESTAMP NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE space
 (
     id         BIGINT      NOT NULL AUTO_INCREMENT,
     host_id    BIGINT      NOT NULL,
     name       VARCHAR(10) NOT NULL,
-    img_url    VARCHAR NULL,
+    img_url    VARCHAR(255) NULL,
     created_at TIMESTAMP   NOT NULL,
     updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE job
 (
     id         BIGINT      NOT NULL AUTO_INCREMENT,
     space_id   BIGINT      NOT NULL,
     name       VARCHAR(10) NOT NULL,
-    slack_url  VARCHAR NULL,
+    slack_url  VARCHAR(255) NULL,
     created_at TIMESTAMP   NOT NULL,
     updated_at TIMESTAMP NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE section
 (
@@ -45,11 +48,12 @@ CREATE TABLE section
     job_id      BIGINT      NOT NULL,
     name        VARCHAR(10) NOT NULL,
     description VARCHAR(128) NULL,
-    image_url   VARCHAR NULL,
+    image_url   VARCHAR(255) NULL,
     created_at  TIMESTAMP   NOT NULL,
     updated_at  TIMESTAMP NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE task
 (
@@ -57,11 +61,12 @@ CREATE TABLE task
     section_id  BIGINT      NOT NULL,
     name        VARCHAR(10) NOT NULL,
     description VARCHAR(128) NULL,
-    image_url   VARCHAR NULL,
+    image_url   VARCHAR(255) NULL,
     created_at  TIMESTAMP   NOT NULL,
     updated_at  TIMESTAMP NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE running_task
 (
@@ -70,7 +75,8 @@ CREATE TABLE running_task
     created_at TIMESTAMP NOT NULL,
     PRIMARY KEY (task_id),
     FOREIGN KEY (task_id) REFERENCES task (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;
 
 CREATE TABLE submission
 (
@@ -79,4 +85,5 @@ CREATE TABLE submission
     author     VARCHAR(10) NOT NULL,
     created_at TIMESTAMP   NOT NULL,
     PRIMARY KEY (id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8;

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -13,57 +13,57 @@ CREATE TABLE host
     github_id      BIGINT       NOT NULL UNIQUE,
     image_url      VARCHAR(255) NOT NULL,
     created_at     TIMESTAMP    NOT NULL,
-    updated_at     TIMESTAMP NULL,
+    updated_at     TIMESTAMP    NULL,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
 CREATE TABLE space
 (
-    id         BIGINT      NOT NULL AUTO_INCREMENT,
-    host_id    BIGINT      NOT NULL,
-    name       VARCHAR(10) NOT NULL,
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    host_id    BIGINT       NOT NULL,
+    name       VARCHAR(10)  NOT NULL,
     img_url    VARCHAR(255) NULL,
-    created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP NULL,
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NULL,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
 CREATE TABLE job
 (
-    id         BIGINT      NOT NULL AUTO_INCREMENT,
-    space_id   BIGINT      NOT NULL,
-    name       VARCHAR(10) NOT NULL,
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    space_id   BIGINT       NOT NULL,
+    name       VARCHAR(10)  NOT NULL,
     slack_url  VARCHAR(255) NULL,
-    created_at TIMESTAMP   NOT NULL,
-    updated_at TIMESTAMP NULL,
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NULL,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
 CREATE TABLE section
 (
-    id          BIGINT      NOT NULL AUTO_INCREMENT,
-    job_id      BIGINT      NOT NULL,
-    name        VARCHAR(10) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    job_id      BIGINT       NOT NULL,
+    name        VARCHAR(10)  NOT NULL,
     description VARCHAR(128) NULL,
     image_url   VARCHAR(255) NULL,
-    created_at  TIMESTAMP   NOT NULL,
-    updated_at  TIMESTAMP NULL,
+    created_at  TIMESTAMP    NOT NULL,
+    updated_at  TIMESTAMP    NULL,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;
 
 CREATE TABLE task
 (
-    id          BIGINT      NOT NULL AUTO_INCREMENT,
-    section_id  BIGINT      NOT NULL,
-    name        VARCHAR(10) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    section_id  BIGINT       NOT NULL,
+    name        VARCHAR(10)  NOT NULL,
     description VARCHAR(128) NULL,
     image_url   VARCHAR(255) NULL,
-    created_at  TIMESTAMP   NOT NULL,
-    updated_at  TIMESTAMP NULL,
+    created_at  TIMESTAMP    NOT NULL,
+    updated_at  TIMESTAMP    NULL,
     PRIMARY KEY (id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8;


### PR DESCRIPTION
## issue
- resolve #583

## 코드 설명
- local test 환경에서 mysql로 동작할 수 있도록 testcontainer를 추가하였습니다.
- mysql로 schema 및 코드들이 변경되었습니다.
- docker가 컴퓨터 환경에 맞지 않게 설치되어있다면 (arm인데 intell 강제 설치) 다시 설치하여야 호환이 빠릅니다.
