### PR TITLE
[BE] Job 저장 시, Task가 존재하지 않으면 예외 발생하지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/JobCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/JobCreateRequest.java
@@ -2,6 +2,7 @@ package com.woowacourse.gongcheck.core.presentation.request;
 
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ public class JobCreateRequest {
     private String name;
 
     @Valid
+    @NotEmpty
     private List<SectionCreateRequest> sections;
 
     private JobCreateRequest() {

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/JobCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/JobCreateRequest.java
@@ -13,7 +13,7 @@ public class JobCreateRequest {
     private String name;
 
     @Valid
-    @NotEmpty
+    @NotEmpty(message = "sections 값은 비어있을 수 없습니다.")
     private List<SectionCreateRequest> sections;
 
     private JobCreateRequest() {

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SectionCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SectionCreateRequest.java
@@ -2,13 +2,14 @@ package com.woowacourse.gongcheck.core.presentation.request;
 
 import java.util.List;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import lombok.Getter;
 
 @Getter
 public class SectionCreateRequest {
 
-    @NotNull(message = "SectionCreateRequest의 name은 null일 수 없습니다.")
+    @NotBlank(message = "SectionCreateRequest의 name은 비어있을 수 없습니다.")
     private String name;
 
     private String description;
@@ -16,6 +17,7 @@ public class SectionCreateRequest {
     private String imageUrl;
 
     @Valid
+    @NotEmpty
     private List<TaskCreateRequest> tasks;
 
     private SectionCreateRequest() {

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SectionCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/SectionCreateRequest.java
@@ -17,7 +17,7 @@ public class SectionCreateRequest {
     private String imageUrl;
 
     @Valid
-    @NotEmpty
+    @NotEmpty(message = "tasks 값은 비어있을 수 없습니다.")
     private List<TaskCreateRequest> tasks;
 
     private SectionCreateRequest() {

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/TaskCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/request/TaskCreateRequest.java
@@ -1,12 +1,12 @@
 package com.woowacourse.gongcheck.core.presentation.request;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class TaskCreateRequest {
 
-    @NotNull(message = "TaskCreateRequest의 name은 null일 수 없습니다.")
+    @NotBlank(message = "TaskCreateRequest의 name은 비어있을 수 없습니다.")
     private String name;
 
     private String description;

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/JobAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/JobAcceptanceTest.java
@@ -47,6 +47,102 @@ class JobAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void Host_토큰으로_Job_생성_시_Job에_대한_Section이_존재하지_않으면_예외가_발생한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        JobCreateRequest request = new JobCreateRequest("청소", List.of());
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .auth().oauth2(token)
+                .when().post("/api/spaces/1/jobs")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void Host_토큰으로_Job_생성_시_Section에_대한_Task가_존재하지_않으면_예외가_발생한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        List<SectionCreateRequest> sections = List
+                .of(new SectionCreateRequest("대강의실", "대강의실 설명", "https://image.gongcheck.shop/degang123", List.of()));
+        JobCreateRequest request = new JobCreateRequest("청소", sections);
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .auth().oauth2(token)
+                .when().post("/api/spaces/1/jobs")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void Host_토큰으로_Job_생성_시_Job의_name이_비어있으면_예외가_발생한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        List<TaskCreateRequest> tasks = List
+                .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
+                        new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
+        List<SectionCreateRequest> sections = List
+                .of(new SectionCreateRequest("", "대강의실 설명", "https://image.gongcheck.shop/degang123", tasks));
+        JobCreateRequest request = new JobCreateRequest("", sections);
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .auth().oauth2(token)
+                .when().post("/api/spaces/1/jobs")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void Host_토큰으로_Job_생성_시_Section의_name이_비어있으면_예외가_발생한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        List<TaskCreateRequest> tasks = List
+                .of(new TaskCreateRequest("책상 닦기", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"),
+                        new TaskCreateRequest("칠판 닦기", "칠판 닦기 설명", "https://image.gongcheck.shop/chilpan123"));
+        List<SectionCreateRequest> sections = List
+                .of(new SectionCreateRequest("", "대강의실 설명", "https://image.gongcheck.shop/degang123", tasks));
+        JobCreateRequest request = new JobCreateRequest("청소", sections);
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .auth().oauth2(token)
+                .when().post("/api/spaces/1/jobs")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void Host_토큰으로_Job_생성_시_Task의_name이_비어있으면_예외가_발생한다() {
+        String token = Host_토큰을_요청한다().getToken();
+
+        List<TaskCreateRequest> tasks = List
+                .of(new TaskCreateRequest("", "책상 닦기 설명", "https://image.gongcheck.shop/checksang123"));
+        List<SectionCreateRequest> sections = List
+                .of(new SectionCreateRequest("대강의실", "대강의실 설명", "https://image.gongcheck.shop/degang123", tasks));
+        JobCreateRequest request = new JobCreateRequest("청소", sections);
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .auth().oauth2(token)
+                .when().post("/api/spaces/1/jobs")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
     void Host_토큰으로_Job을_수정한다() {
         String token = Host_토큰을_요청한다().getToken();
 


### PR DESCRIPTION
## issue
- resolve #592 

## 기존 코드의 문제점
기존에 Job 생성 시, Section의 Task가 비어있어도 저장 로직이 정상 수행된다.

## 코드 설명
DTO에서 Job저장 시, Section 값이 비어있는지 or Section에 해당하는 Task가 비어있지는 않은지 체크하는 검증을 추가했습니다.

DTO에 추가한 이유는 다음과 같습니다.
양방향 매핑이 되어있다면 Section에서 Task가 비어있는지 체크할 수 있겠지만, 현재는 단방향으로 되어 있습니다.
그렇다면 Service에서 검증해야 하는데, 결국 DTO에 값이 비어있지 않은지를 Service에서 체크해줘야 합니다.
때문에 이 로직을 Service에 추가하는 것 보다 DTO로 변환하는 과정에서 체크하는 것이 더 적합하다 생각해서 현재 로직으로 작성했습니다. 
