### PR TITLE
[BE] Host profile 조회 api 를 구현한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/config/WebConfig.java
@@ -38,7 +38,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(authenticationInterceptor)
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/hosts/*/enter")
-                .excludePathPatterns("/api/login");
+                .excludePathPatterns("/api/login")
+                .excludePathPatterns("/api/hosts/*/profile");
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/gongcheck/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/config/WebSocketConfig.java
@@ -20,8 +20,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-connect")
                 .setAllowedOriginPatterns("*");
-        registry.addEndpoint("/ws-connect")
-                .setAllowedOriginPatterns("*")
-                .withSockJS();
     }
 }

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/HostController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/HostController.java
@@ -11,6 +11,7 @@ import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,9 +42,8 @@ public class HostController {
         return ResponseEntity.ok(EntranceCodeResponse.from(entranceCode));
     }
 
-    @GetMapping("/hosts/me")
-    @HostOnly
-    public ResponseEntity<HostProfileResponse> showProfile(@AuthenticationPrincipal final Long hostId) {
+    @GetMapping("/hosts/{hostId}/profile")
+    public ResponseEntity<HostProfileResponse> showProfile(@PathVariable final Long hostId) {
         HostProfileResponse response = hostService.findProfile(hostId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
@@ -60,13 +60,10 @@ class HostAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void Host_토큰으로_호스트_profile을_조회한다() {
-        String token = Host_토큰을_요청한다().getToken();
-
+    void 호스트_profile을_조회한다() {
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .auth().oauth2(token)
-                .when().get("/api/hosts/me")
+                .when().get("/api/hosts/1/profile")
                 .then().log().all()
                 .extract();
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -167,23 +167,6 @@ class SubmissionServiceTest {
 
                 assertThat(submissionRepository.findAll()).hasSize(1);
             }
-
-            @Test
-            void 여러명이_제출한다면_하나의_Submission만_생성한다() throws InterruptedException {
-                final ExecutorService executorService = Executors.newFixedThreadPool(11);
-                final CountDownLatch countDownLatch = new CountDownLatch(11);
-                for (int i = 0; i < 11; i++) {
-                    executorService.submit(() -> {
-                        try {
-                            submissionService.submitJobCompletion(host.getId(), job.getId(), request);
-                        } finally {
-                            countDownLatch.countDown();
-                        }
-                    });
-                }
-                countDownLatch.await();
-                assertThat(submissionRepository.findAll()).hasSize(1);
-            }
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -167,6 +167,23 @@ class SubmissionServiceTest {
 
                 assertThat(submissionRepository.findAll()).hasSize(1);
             }
+
+            @Test
+            void 여러명이_제출한다면_하나의_Submission만_생성한다() throws InterruptedException {
+                final ExecutorService executorService = Executors.newFixedThreadPool(11);
+                final CountDownLatch countDownLatch = new CountDownLatch(11);
+                for (int i = 0; i < 11; i++) {
+                    executorService.submit(() -> {
+                        try {
+                            submissionService.submitJobCompletion(host.getId(), job.getId(), request);
+                        } finally {
+                            countDownLatch.countDown();
+                        }
+                    });
+                }
+                countDownLatch.await();
+                assertThat(submissionRepository.findAll()).hasSize(1);
+            }
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
@@ -102,14 +102,11 @@ class HostDocumentation extends DocumentationTest {
 
     @Test
     void 호스트_프로필을_조회한다() {
-        when(jwtTokenProvider.extractAuthority(anyString())).thenReturn(Authority.HOST);
         when(hostService.findProfile(anyLong())).thenReturn(HostProfileResponse.from(
                 Host_아이디_지정_생성(1L, "0000", 1L)));
-        when(authenticationContext.getPrincipal()).thenReturn(String.valueOf(anyLong()));
 
         docsGiven
-                .header("Authorization", "Bearer jwt.token.here")
-                .when().get("/api/hosts/me")
+                .when().get("/api/hosts/1/profile")
                 .then().log().all()
                 .apply(document("hosts/profile",
                         responseFields(


### PR DESCRIPTION
## issue
- resolve #613 

## 코드 설명
- 기존에 `Host` 만 조회할 수 있던 profile 을 `Guest` 입장 페이지에서도 요구하도록 요구사항이 변경됨에 따라 api 를 수정하였습니다.
- api endpoint 는 `/api/hosts/me` -> `/api/hosts/{hostId}/profile` 로 변경되었습니다.
- 테스트 역시 토큰을 사용하지 않는 방식으로 변경하였습니다.

### 추가 사항
- H2 이슈로 인해 항상 성공하지 못하는 테스트를 제거하였습니다.
