### PR TITLE
[FE] SockJs를 제거한다.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,12 +32,10 @@
         "@lhci/cli": "^0.9.0",
         "@stomp/stompjs": "^6.1.2",
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
-        "@types/event-source-polyfill": "^1.0.0",
         "@types/node": "^18.0.0",
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
         "@types/react-transition-group": "^4.4.5",
-        "@types/sockjs-client": "^1.5.1",
         "@typescript-eslint/eslint-plugin": "^5.30.3",
         "@typescript-eslint/parser": "^5.30.3",
         "@webpack-cli/generators": "^2.5.0",
@@ -52,13 +50,11 @@
         "eslint": "^8.19.0",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-react": "^7.30.1",
-        "event-source-polyfill": "1.0.28",
         "file-loader": "^6.2.0",
         "gongcheck-util-types": "^1.1.0",
         "html-webpack-plugin": "^5.5.0",
         "nanoid": "^4.0.0",
         "prettier": "^2.7.1",
-        "sockjs-client": "^1.6.1",
         "start-server-and-test": "^1.14.0",
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4",
@@ -3130,12 +3126,6 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
-    "node_modules/@types/event-source-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.0.tgz",
-      "integrity": "sha512-b8O8/rg7NIW0iJ8i9MNDBZqPljHA+b7AjC3QFqH3dSyW6vgrl3oBgyIv5dw2fibh5enHHDkkPZG5PHza7U4NRw==",
-      "dev": true
-    },
     "node_modules/@types/expect": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
@@ -3324,12 +3314,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/sockjs-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.1.tgz",
-      "integrity": "sha512-bmZM6A1GPdjF0bcuIUC+50hZEMGkzMsiG9by6X9U+7IZFOiPtz7MJ9h05FSpPVxlj4i+TzzoG3ESo1FJlbLb6A==",
-      "dev": true
     },
     "node_modules/@types/vinyl": {
       "version": "2.0.6",
@@ -8393,12 +8377,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-source-polyfill": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.28.tgz",
-      "integrity": "sha512-S4Je04Br394hKTiyUXKAkNpha/7r172rLNu76sdxB3Nw2g9sjuEc4kxMu/miaikvWA4jvJ2x6Xkg6BOAb1aM7g==",
-      "dev": true
-    },
     "node_modules/event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -8433,15 +8411,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/execa": {
@@ -14678,12 +14647,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -16270,34 +16233,6 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
-      }
-    },
-    "node_modules/sockjs-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
-      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^3.2.7",
-        "eventsource": "^2.0.2",
-        "faye-websocket": "^0.11.4",
-        "inherits": "^2.0.4",
-        "url-parse": "^1.5.10"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/socks": {
@@ -17941,16 +17876,6 @@
         "file-loader": {
           "optional": true
         }
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url-parse-lax": {
@@ -22495,12 +22420,6 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
-    "@types/event-source-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.0.tgz",
-      "integrity": "sha512-b8O8/rg7NIW0iJ8i9MNDBZqPljHA+b7AjC3QFqH3dSyW6vgrl3oBgyIv5dw2fibh5enHHDkkPZG5PHza7U4NRw==",
-      "dev": true
-    },
     "@types/expect": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
@@ -22689,12 +22608,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/sockjs-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.1.tgz",
-      "integrity": "sha512-bmZM6A1GPdjF0bcuIUC+50hZEMGkzMsiG9by6X9U+7IZFOiPtz7MJ9h05FSpPVxlj4i+TzzoG3ESo1FJlbLb6A==",
-      "dev": true
     },
     "@types/vinyl": {
       "version": "2.0.6",
@@ -26636,12 +26549,6 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
-    "event-source-polyfill": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.28.tgz",
-      "integrity": "sha512-S4Je04Br394hKTiyUXKAkNpha/7r172rLNu76sdxB3Nw2g9sjuEc4kxMu/miaikvWA4jvJ2x6Xkg6BOAb1aM7g==",
-      "dev": true
-    },
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -26673,12 +26580,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
-    },
-    "eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true
     },
     "execa": {
@@ -31474,12 +31375,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -32718,30 +32613,6 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
-      }
-    },
-    "sockjs-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
-      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "eventsource": "^2.0.2",
-        "faye-websocket": "^0.11.4",
-        "inherits": "^2.0.4",
-        "url-parse": "^1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "socks": {
@@ -33987,16 +33858,6 @@
         "loader-utils": "^2.0.0",
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "recoil": "^0.7.4"
   },
   "devDependencies": {
-    "sockjs-client": "^1.6.1",
     "@stomp/stompjs": "^6.1.2",
     "@babel/core": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
@@ -46,12 +45,10 @@
     "@emotion/styled": "^11.9.3",
     "@lhci/cli": "^0.9.0",
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",
-    "@types/event-source-polyfill": "^1.0.0",
     "@types/node": "^18.0.0",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@types/react-transition-group": "^4.4.5",
-    "@types/sockjs-client": "^1.5.1",
     "@typescript-eslint/eslint-plugin": "^5.30.3",
     "@typescript-eslint/parser": "^5.30.3",
     "@webpack-cli/generators": "^2.5.0",
@@ -66,7 +63,6 @@
     "eslint": "^8.19.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-react": "^7.30.1",
-    "event-source-polyfill": "1.0.28",
     "file-loader": "^6.2.0",
     "gongcheck-util-types": "^1.1.0",
     "html-webpack-plugin": "^5.5.0",

--- a/frontend/src/pages/user/TaskList/useTaskList.tsx
+++ b/frontend/src/pages/user/TaskList/useTaskList.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useRef } from 'react';
 import { useQuery } from 'react-query';
 import { useLocation, useParams } from 'react-router-dom';
-import SockJS from 'sockjs-client';
 
 import DetailInfoModal from '@/components/user/DetailInfoModal';
 import NameModal from '@/components/user/NameModal';
@@ -17,8 +16,6 @@ import apis from '@/apis';
 
 import { ID, SectionType } from '@/types';
 import { ApiTaskData } from '@/types/apis';
-
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
 const useTaskList = () => {
   const { spaceId, jobId } = useParams() as { spaceId: ID; jobId: ID };
@@ -85,8 +82,7 @@ const useTaskList = () => {
   };
 
   useEffect(() => {
-    const sock = new SockJS(`${API_URL}/ws-connect`);
-    stomp.current = Stomp.over(sock);
+    stomp.current = Stomp.client(`${process.env.REACT_APP_WS_URL}/ws-connect`);
 
     stomp.current.connect({}, () => {
       stomp.current.subscribe(`/topic/jobs/${jobId}`, (data: any) => {
@@ -102,7 +98,6 @@ const useTaskList = () => {
 
     return () => {
       stomp.current.disconnect();
-      sock.close();
     };
   }, []);
 


### PR DESCRIPTION
## issue
- resolve #617

## 코드 설명
- SockJS 없이 stomp 만으로 웹소켓을 구현한다.
 - SockJS는 웹소켓을 지원하지 않는 브라우저에서 socket과 비슷한 환경을 제공해주는 라이브러리이다.
 - 백엔드의 웹소켓 부하 테스트 과정에서 SockJS가 어울리지 않다는 의견이 있어서, SockJS에 대한 의존성을 제거한다.
