### PR TITLE
[BE] Host profile 조회하는 api를 EntranceCode를 받도록 수정한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/gongcheck/core/application/HostService.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/application/HostService.java
@@ -34,7 +34,8 @@ public class HostService {
         return entranceCodeProvider.createEntranceCode(host.getId());
     }
 
-    public HostProfileResponse findProfile(final Long hostId) {
+    public HostProfileResponse findProfile(final String entranceCode) {
+        Long hostId = entranceCodeProvider.parseId(entranceCode);
         Host host = hostRepository.getById(hostId);
         return HostProfileResponse.from(host);
     }

--- a/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/HostController.java
+++ b/backend/src/main/java/com/woowacourse/gongcheck/core/presentation/HostController.java
@@ -42,9 +42,9 @@ public class HostController {
         return ResponseEntity.ok(EntranceCodeResponse.from(entranceCode));
     }
 
-    @GetMapping("/hosts/{hostId}/profile")
-    public ResponseEntity<HostProfileResponse> showProfile(@PathVariable final Long hostId) {
-        HostProfileResponse response = hostService.findProfile(hostId);
+    @GetMapping("/hosts/{entranceCode}/profile")
+    public ResponseEntity<HostProfileResponse> showProfile(@PathVariable final String entranceCode) {
+        HostProfileResponse response = hostService.findProfile(entranceCode);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/AcceptanceTest.java
@@ -32,7 +32,7 @@ class AcceptanceTest {
     protected ImageUploader imageUploader;
 
     @Autowired
-    private EntranceCodeProvider entranceCodeProvider;
+    protected EntranceCodeProvider entranceCodeProvider;
 
     @Autowired
     private DatabaseInitializer databaseInitializer;

--- a/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/acceptance/HostAcceptanceTest.java
@@ -61,9 +61,10 @@ class HostAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 호스트_profile을_조회한다() {
+        String entranceCode = entranceCodeProvider.createEntranceCode(1L);
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .when().get("/api/hosts/1/profile")
+                .when().get("/api/hosts/" + entranceCode + "/profile")
                 .then().log().all()
                 .extract();
 

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/HostServiceTest.java
@@ -11,6 +11,7 @@ import com.woowacourse.gongcheck.core.application.response.HostProfileResponse;
 import com.woowacourse.gongcheck.core.domain.host.Host;
 import com.woowacourse.gongcheck.core.presentation.request.HostProfileChangeRequest;
 import com.woowacourse.gongcheck.core.presentation.request.SpacePasswordChangeRequest;
+import com.woowacourse.gongcheck.exception.InfrastructureException;
 import com.woowacourse.gongcheck.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -106,28 +107,28 @@ class HostServiceTest {
     class findProfile_메소드는 {
 
         @Nested
-        class 존재하는_HostId를_입력받는_경우 {
+        class 존재하는_EntranceCode를_입력받는_경우 {
 
             private final Host host = repository.save(Host_생성("1234", 1L));
 
             @Test
             void profile을_반환한다() {
-                HostProfileResponse actual = hostService.findProfile(host.getId());
+                String entranceCode = entranceCodeProvider.createEntranceCode(host.getId());
+                HostProfileResponse actual = hostService.findProfile(entranceCode);
                 assertThat(actual).extracting("imageUrl", "nickname")
                         .containsExactly("image.url", "nickname");
             }
         }
 
         @Nested
-        class 존재하지_않는_HostId를_입력받는_경우 {
+        class 존재하지_않는_EntranceCode를_입력받는_경우 {
 
-            private static final long NON_EXIST_HOST_ID = 0L;
+            private static final String NON_EXIST_ENTRANCE_CODE = "ABCDEFGHIJKLMNOP";
 
             @Test
             void 예외를_발생시킨다() {
-                assertThatThrownBy(() -> hostService.findProfile(NON_EXIST_HOST_ID))
-                        .isInstanceOf(NotFoundException.class)
-                        .hasMessageContaining("존재하지 않는 호스트입니다.");
+                assertThatThrownBy(() -> hostService.findProfile(NON_EXIST_ENTRANCE_CODE))
+                        .isInstanceOf(InfrastructureException.class);
             }
         }
     }

--- a/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/core/application/SubmissionServiceTest.java
@@ -152,7 +152,7 @@ class SubmissionServiceTest {
             }
 
             @Test
-            void 여러명이_제출한다면_하나의_Submission만_생성한다() {
+            void 여러명이_제출한다면_하나의_Submission만_생성한다() throws InterruptedException {
                 final ExecutorService executorService = Executors.newFixedThreadPool(11);
                 final CountDownLatch countDownLatch = new CountDownLatch(11);
                 for (int i = 0; i < 11; i++) {
@@ -164,7 +164,7 @@ class SubmissionServiceTest {
                         }
                     });
                 }
-
+                countDownLatch.await();
                 assertThat(submissionRepository.findAll()).hasSize(1);
             }
         }

--- a/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
+++ b/backend/src/test/java/com/woowacourse/gongcheck/documentation/HostDocumentation.java
@@ -102,7 +102,7 @@ class HostDocumentation extends DocumentationTest {
 
     @Test
     void 호스트_프로필을_조회한다() {
-        when(hostService.findProfile(anyLong())).thenReturn(HostProfileResponse.from(
+        when(hostService.findProfile(anyString())).thenReturn(HostProfileResponse.from(
                 Host_아이디_지정_생성(1L, "0000", 1L)));
 
         docsGiven


### PR DESCRIPTION
## issue
- resolve #621 

## 코드 설명
- host `id`를 받아 프로필 조회하던 api를 `entranceCode` 를 통해 조회할 수 있도록 API 를 수정하였습니다.
- 추가로 동시 제출 테스트코드를 수정하였습니다.

### 개선 사항
- 해싱된 hostId 값인 `entranceCode` 라는 네이밍이 적절하지 않을 수 있을 것 같습니다. 새로운 네이밍에 대해 의논해보면 좋을 것 같습니다.
