### PR TITLE
[FE] 타입스크립트 옵션을 프로젝트에 맞게 수정한다.

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "isolatedModules": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,33 +1,21 @@
 {
   "compilerOptions": {
     "target": "es2016",
-    "composite": true,
+    "composite": false,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "noEmit": true,
     "isolatedModules": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "useUnknownInCatchVariables": true,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    },
-    "types": ["cypress", "node"]
+    }
   },
-  "include": ["src", "cypress"],
-  "exclude": ["**/*.cy.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## issue
- resolve #634

## 코드 설명
- babel로 컴파일을 진행하기때문에 tsconfig의 컴파일 관련은 전부 제거하였습니다.
- stict 모드와 중첩되는 사항은 제거하였습니다.
```json
// strict: true
{
  "alwaysStrict": true,
  "strictNullChecks": true,
  "strictFunctionTypes": true,
  "strictBindCallApply": true,
  "strictPropertyInitialization": true,
  "noImplicitAny": true,
  "noImplicitThis": true,
  "useUnknownInCatchVariables": true,
}
```
   
- 그 외의 변경된 옵션에 대한 설명은 코멘트로 남기겠습니다.


