### PR TITLE
[FE] 작동이 없어서 웹소켓 연결이 종료되었을때, 재연결을 할 수 있도록 한다.

### DIFF
--- a/frontend/src/pages/user/TaskList/useTaskList.tsx
+++ b/frontend/src/pages/user/TaskList/useTaskList.tsx
@@ -86,6 +86,8 @@ const useTaskList = () => {
   useEffect(() => {
     stomp.current = Stomp.client(`${process.env.REACT_APP_WS_URL}/ws-connect`);
 
+    stomp.current.reconnect_delay = 1000;
+
     stomp.current.connect({}, () => {
       stomp.current.subscribe(`/topic/jobs/${jobId}`, (data: any) => {
         setSectionsData(JSON.parse(data.body));


### PR DESCRIPTION
## issue
- resolve #636

## 코드 설명
- stomp.js reconnect_delay 1초로 설정
